### PR TITLE
Update Protocol model

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ lazy val V = new {
   val betterMonadicFor: String = "0.2.4"
   val cats: String             = "1.5.0"
   val catsScalacheck: String   = "0.1.0"
+  val mouse: String            = "0.20"
   val circe: String            = "0.11.1"
   val kindProjector: String    = "0.9.9"
   val paradise: String         = "2.1.1"
@@ -106,6 +107,7 @@ lazy val commonSettings = Seq(
   ThisBuild / scalacOptions -= "-Xplugin-require:macroparadise",
   libraryDependencies ++= Seq(
     %%("cats-core", V.cats),
+    "org.typelevel" %% "mouse" % V.mouse,
     %%("shapeless", V.shapeless),
     %%("pureconfig", V.pureConfig),
     "io.frees" %% "skeuomorph" % V.skeumorph,

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import sbtorgpolicies.templates._
 import sbtorgpolicies.templates.badges._
 
 lazy val V = new {
-  val betterMonadicFor: String = "0.2.4"
+  val betterMonadicFor: String = "0.3.0-M4"
   val cats: String             = "1.5.0"
   val catsScalacheck: String   = "0.1.0"
   val mouse: String            = "0.20"

--- a/modules/common/src/main/scala/higherkindness/compendium/models.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models.scala
@@ -16,4 +16,4 @@
 
 package higherkindness.compendium.models
 
-final case class Protocol(name: String, raw: String)
+final case class Protocol(raw: String, version: Option[String] = None)

--- a/modules/common/src/main/scala/higherkindness/compendium/models.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models.scala
@@ -16,4 +16,4 @@
 
 package higherkindness.compendium.models
 
-final case class Protocol(raw: String, version: Option[String] = None)
+final case class Protocol(raw: String)

--- a/modules/server/src/main/scala/higherkindness/compendium/Main.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/Main.scala
@@ -37,7 +37,7 @@ object CompendiumStreamApp {
     for {
       conf <- Stream.eval(Effect[F].delay(pureconfig.loadConfigOrThrow[CompendiumConfig]))
       storage           = FileStorage.impl[F](conf.storage)
-      dbService         = DBServiceStorage.impl[F](storage)
+      dbService         = DBServiceStorage.impl[F](Effect[F], storage)
       utils             = ProtocolUtils.impl[F]()
       compendiumService = CompendiumService.impl[F](Effect[F], storage, dbService, utils)
       service           = RootService.rootRouteService(Effect[F], compendiumService)

--- a/modules/server/src/main/scala/higherkindness/compendium/Main.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/Main.scala
@@ -20,10 +20,10 @@ import cats.effect._
 import cats.syntax.functor._
 import fs2.Stream
 import higherkindness.compendium.core.{CompendiumService, ProtocolUtils}
-import higherkindness.compendium.db.DBServiceStorage
+import higherkindness.compendium.db.{DBService, DBServiceStorage}
 import higherkindness.compendium.http.RootService
 import higherkindness.compendium.models.CompendiumConfig
-import higherkindness.compendium.storage.FileStorage
+import higherkindness.compendium.storage.{FileStorage, Storage}
 import pureconfig.generic.auto._
 
 object Main extends IOApp {
@@ -36,11 +36,11 @@ object CompendiumStreamApp {
   def stream[F[_]: ConcurrentEffect]: Stream[F, ExitCode] =
     for {
       conf <- Stream.eval(Effect[F].delay(pureconfig.loadConfigOrThrow[CompendiumConfig]))
-      storage           = FileStorage.impl[F](conf.storage)
-      dbService         = DBServiceStorage.impl[F](Effect[F], storage)
-      utils             = ProtocolUtils.impl[F]()
-      compendiumService = CompendiumService.impl[F](Effect[F], storage, dbService, utils)
-      service           = RootService.rootRouteService(Effect[F], compendiumService)
+      implicit0(storage: Storage[F])                     = FileStorage.impl[F](conf.storage)
+      implicit0(dbService: DBService[F])                 = DBServiceStorage.impl[F]
+      implicit0(utils: ProtocolUtils[F])                 = ProtocolUtils.impl[F]()
+      implicit0(compendiumService: CompendiumService[F]) = CompendiumService.impl[F]
+      service                                            = RootService.rootRouteService
       code <- CompendiumServerStream.serverStream(conf.http, service)
     } yield code
 }

--- a/modules/server/src/main/scala/higherkindness/compendium/db/DBService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/db/DBService.scala
@@ -19,10 +19,7 @@ package higherkindness.compendium.db
 import higherkindness.compendium.models.Protocol
 
 trait DBService[F[_]] {
-
-  def addProtocol(protocol: Protocol): F[Int]
-  def lastProtocol(): F[Option[Protocol]]
-
+  def addProtocol(id: String, protocol: Protocol): F[Unit]
 }
 
 object DBService {

--- a/modules/server/src/main/scala/higherkindness/compendium/db/DBServiceStorage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/db/DBServiceStorage.scala
@@ -25,15 +25,15 @@ import higherkindness.compendium.storage.Storage
 
 object DBServiceStorage {
 
-  def impl[F[_]: Sync](storage: Storage[F]): DBService[F] =
+  def impl[F[_]: Sync: Storage]: DBService[F] =
     new DBService[F] {
 
       override def addProtocol(id: String, protocol: Protocol): F[Unit] =
         for {
-          exists <- storage.checkIfExists(id)
+          exists <- Storage[F].checkIfExists(id)
           _ <- exists.fold(
             Sync[F].raiseError(new ProtocolAlreadyExists(s"Protocol with id ${id} already exists")),
-            storage.store(id, protocol))
+            Storage[F].store(id, protocol))
         } yield ()
     }
 }

--- a/modules/server/src/main/scala/higherkindness/compendium/db/DBServiceStorage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/db/DBServiceStorage.scala
@@ -17,8 +17,7 @@
 package higherkindness.compendium.db
 
 import cats.effect.Sync
-import cats.syntax.functor._
-import cats.syntax.flatMap._
+import cats.implicits._
 import higherkindness.compendium.models.Protocol
 import higherkindness.compendium.storage.Storage
 
@@ -27,16 +26,8 @@ object DBServiceStorage {
   def impl[F[_]: Sync](storage: Storage[F]): DBService[F] =
     new DBService[F] {
 
-      override def addProtocol(protocol: Protocol): F[Int] =
-        for {
-          number <- storage.numberProtocol()
-          _      <- storage.store(number + 1, protocol)
-        } yield number + 1
-
-      override def lastProtocol(): F[Option[Protocol]] =
-        for {
-          number   <- storage.numberProtocol()
-          protocol <- storage.recover(number)
-        } yield protocol
+      // TODO Check id does not exists
+      override def addProtocol(id: String, protocol: Protocol): F[Unit] =
+        storage.store(id, protocol) *> Sync[F].unit
     }
 }

--- a/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
@@ -39,21 +39,22 @@ object RootService {
     HttpRoutes.of[F] {
       case GET -> Root / "ping" => Ok("pong".asJson)
 
-      case req @ POST -> Root / "v0" / "protocol" =>
+      case req @ POST -> Root / "v0" / "protocol" / id =>
         Sync[F].recoverWith(
           for {
             protocol <- req.as[Protocol]
-            id       <- CompendiumService[F].storeProtocol(protocol)
-            resp     <- Ok().map(_.putHeaders(Location(req.uri.withPath(s"${req.uri.path}/$id"))))
+            _        <- CompendiumService[F].storeProtocol(id, protocol)
+            resp     <- Created().map(_.putHeaders(Location(req.uri.withPath(s"${req.uri.path}"))))
           } yield resp
         ) {
+          // TODO Handle id already exists error
           case e: org.apache.avro.SchemaParseException => BadRequest(e.getMessage.asJson)
           case _                                       => InternalServerError()
         }
 
-      case GET -> Root / "v0" / "protocol" / IntVar(protocolId) =>
+      case GET -> Root / "v0" / "protocol" / id =>
         for {
-          protocol <- CompendiumService[F].recoverProtocol(protocolId)
+          protocol <- CompendiumService[F].recoverProtocol(id)
           resp     <- protocol.fold(NotFound())(Ok(_))
         } yield resp
 

--- a/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
@@ -21,7 +21,7 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import org.http4s.circe.CirceEntityCodec._
 import io.circe.syntax._
-import higherkindness.compendium.models.Protocol
+import higherkindness.compendium.models._
 import org.http4s.dsl.Http4sDsl
 import Decoders._
 import Encoders._
@@ -49,6 +49,7 @@ object RootService {
         ) {
           // TODO Handle id already exists error
           case e: org.apache.avro.SchemaParseException => BadRequest(e.getMessage.asJson)
+          case t: ProtocolAlreadyExists                => Conflict(t.getMessage.asJson)
           case _                                       => InternalServerError()
         }
 

--- a/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
@@ -47,7 +47,6 @@ object RootService {
             resp     <- Created().map(_.putHeaders(Location(req.uri.withPath(s"${req.uri.path}"))))
           } yield resp
         ) {
-          // TODO Handle id already exists error
           case e: org.apache.avro.SchemaParseException => BadRequest(e.getMessage.asJson)
           case t: ProtocolAlreadyExists                => Conflict(t.getMessage.asJson)
           case _                                       => InternalServerError()

--- a/modules/server/src/main/scala/higherkindness/compendium/models/errors.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/models/errors.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.compendium.models
+
+class ProtocolAlreadyExists(message: String) extends Exception(message)

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
@@ -54,5 +54,8 @@ object FileStorage {
             }
           }
         } yield protocol
+
+      override def checkIfExists(id: String): F[Boolean] =
+        Sync[F].catchNonFatal(new File(s"${config.path}${File.separator}${id}")).map(_.exists)
     }
 }

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/Storage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/Storage.scala
@@ -22,6 +22,7 @@ trait Storage[F[_]] {
 
   def store(id: String, protocol: Protocol): F[Unit]
   def recover(id: String): F[Option[Protocol]]
+  def checkIfExists(id: String): F[Boolean]
 }
 
 object Storage {

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/Storage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/Storage.scala
@@ -20,9 +20,8 @@ import higherkindness.compendium.models.Protocol
 
 trait Storage[F[_]] {
 
-  def store(id: Int, protocol: Protocol): F[Unit]
-  def recover(id: Int): F[Option[Protocol]]
-  def numberProtocol(): F[Int]
+  def store(id: String, protocol: Protocol): F[Unit]
+  def recover(id: String): F[Option[Protocol]]
 }
 
 object Storage {

--- a/modules/server/src/test/scala/higherkindness/compendium/CompendiumArbitrary.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/CompendiumArbitrary.scala
@@ -18,13 +18,11 @@ package higherkindness.compendium
 
 import higherkindness.compendium.models.Protocol
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.cats.implicits._
-import cats.syntax.apply._
 
 trait CompendiumArbitrary {
 
   implicit val protocolArbitrary: Arbitrary[Protocol] = Arbitrary {
-    (Gen.alphaNumStr, Gen.alphaNumStr).mapN(Protocol.apply)
+    (Gen.alphaNumStr).map(Protocol(_))
   }
 
 }

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceSpec.scala
@@ -41,6 +41,9 @@ object CompendiumServiceSpec extends Specification with ScalaCheck {
 
     override def recover(id: String): IO[Option[Protocol]] =
       if (id == identifier) IO(proto) else IO(None)
+
+    override def checkIfExists(id: String): IO[Boolean] =
+      if (id == identifier) IO(false) else IO(true)
   }
 
   def protocolUtilsIO(pro: Protocol, valid: Boolean): ProtocolUtils[IO] =

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceSpec.scala
@@ -54,7 +54,7 @@ object CompendiumServiceSpec extends Specification with ScalaCheck {
         else IO.raiseError(new org.apache.avro.SchemaParseException("Error"))
     }
 
-  private val dummyProtocol: Protocol = Protocol("", "")
+  private val dummyProtocol: Protocol = Protocol("")
 
   "Store protocol" >> {
     "If it's a valid protocol we store it" >> prop { identifier: Int =>

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceStub.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.compendium.core
+
+import cats.effect.IO
+import higherkindness.compendium.models.Protocol
+
+class CompendiumServiceStub(val protocolOpt: Option[Protocol]) extends CompendiumService[IO] {
+  override def storeProtocol(id: String, protocol: Protocol): IO[Unit] = IO.unit
+  override def recoverProtocol(id: String): IO[Option[Protocol]]       = IO(protocolOpt)
+}

--- a/modules/server/src/test/scala/higherkindness/compendium/core/ProtocolUtilsSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/ProtocolUtilsSpec.scala
@@ -33,8 +33,8 @@ object ProtocolUtilsSpec extends Specification with ScalaCheck {
   "Given a raw protocol text" >> {
     "Returns a protocol if the avro text it is correct" >> {
       val stream: InputStream = getClass.getResourceAsStream("/correct.avro")
-      val text                = scala.io.Source.fromInputStream(stream).getLines.mkString
-      val protocol            = Protocol(text)
+      val text: String        = scala.io.Source.fromInputStream(stream).getLines.mkString
+      val protocol: Protocol  = Protocol(text)
 
       utils.validateProtocol(protocol).unsafeRunSync === protocol
     }

--- a/modules/server/src/test/scala/higherkindness/compendium/core/ProtocolUtilsSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/ProtocolUtilsSpec.scala
@@ -34,7 +34,7 @@ object ProtocolUtilsSpec extends Specification with ScalaCheck {
     "Returns a protocol if the avro text it is correct" >> {
       val stream: InputStream = getClass.getResourceAsStream("/correct.avro")
       val text                = scala.io.Source.fromInputStream(stream).getLines.mkString
-      val protocol            = Protocol("name", text)
+      val protocol            = Protocol(text)
 
       utils.validateProtocol(protocol).unsafeRunSync === protocol
     }

--- a/modules/server/src/test/scala/higherkindness/compendium/db/DBServiceStorageSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/db/DBServiceStorageSpec.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-/*
 package higherkindness.compendium.db
 
 import cats.effect.IO
+import higherkindness.compendium.models.{Protocol, ProtocolAlreadyExists}
+import higherkindness.compendium.storage.StorageStub
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 
@@ -25,23 +26,22 @@ object DBServiceStorageSpec extends Specification with ScalaCheck {
 
   sequential
 
-  "Store protocol" >> {
-    "If it's a valid protocol we store it" >> prop { id: String =>
-      implicit val storage       = new StorageStub(Some(dummyProtocol), id)
+  private val dummyProtocol: Protocol = Protocol("")
 
-      DBServiceStorage.impl[IO].storeProtocol(id, dummyProtocol).map(_ => success).unsafeRunSync()
+  "Store protocol" >> {
+    "If the protocol doesn't exists we store it" >> prop { id: String =>
+      implicit val storage = new StorageStub(Some(dummyProtocol), id)
+
+      DBServiceStorage.impl[IO].addProtocol(id, dummyProtocol).map(_ => success).unsafeRunSync()
     }
 
-    "If it's an invalid protocol we raise an error" >> prop { id: String =>
-      implicit val dbService     = new DBServiceStub()
-      implicit val storage       = new StorageStub(Some(dummyProtocol), id)
-      implicit val protocolUtils = protocolUtilsIO(dummyProtocol, false)
+    "If the protocol exists we raised an error" >> prop { id: String =>
+      implicit val storage = new StorageStub(Some(dummyProtocol), id) {
+        override def checkIfExists(id: String): IO[Boolean] = IO(true)
+      }
 
-      CompendiumService
-        .impl[IO]
-        .storeProtocol(id, dummyProtocol)
-        .unsafeRunSync must throwA[org.apache.avro.SchemaParseException]
+      DBServiceStorage.impl[IO].addProtocol(id, dummyProtocol).unsafeRunSync must
+        throwA[ProtocolAlreadyExists]
     }
   }
 }
- */

--- a/modules/server/src/test/scala/higherkindness/compendium/db/DBServiceStorageSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/db/DBServiceStorageSpec.scala
@@ -14,35 +14,22 @@
  * limitations under the License.
  */
 
-package higherkindness.compendium.core
+/*
+package higherkindness.compendium.db
 
 import cats.effect.IO
-import higherkindness.compendium.db.DBServiceStub
-import higherkindness.compendium.models.Protocol
-import higherkindness.compendium.storage.StorageStub
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 
-object CompendiumServiceSpec extends Specification with ScalaCheck {
+object DBServiceStorageSpec extends Specification with ScalaCheck {
 
   sequential
 
-  def protocolUtilsIO(pro: Protocol, valid: Boolean): ProtocolUtils[IO] =
-    new ProtocolUtils[IO] {
-      override def validateProtocol(protocol: Protocol): IO[Protocol] =
-        if (valid) IO(pro)
-        else IO.raiseError(new org.apache.avro.SchemaParseException("Error"))
-    }
-
-  private val dummyProtocol: Protocol = Protocol("")
-
   "Store protocol" >> {
     "If it's a valid protocol we store it" >> prop { id: String =>
-      implicit val dbService     = new DBServiceStub()
       implicit val storage       = new StorageStub(Some(dummyProtocol), id)
-      implicit val protocolUtils = protocolUtilsIO(dummyProtocol, true)
 
-      CompendiumService.impl[IO].storeProtocol(id, dummyProtocol).map(_ => success).unsafeRunSync()
+      DBServiceStorage.impl[IO].storeProtocol(id, dummyProtocol).map(_ => success).unsafeRunSync()
     }
 
     "If it's an invalid protocol we raise an error" >> prop { id: String =>
@@ -56,15 +43,5 @@ object CompendiumServiceSpec extends Specification with ScalaCheck {
         .unsafeRunSync must throwA[org.apache.avro.SchemaParseException]
     }
   }
-
-  "Recover protocol" >> {
-    "Given a identifier we recover the protocol" >> prop { id: String =>
-      implicit val dbService     = new DBServiceStub()
-      implicit val storage       = new StorageStub(Some(dummyProtocol), id)
-      implicit val protocolUtils = protocolUtilsIO(dummyProtocol, true)
-
-      CompendiumService.impl[IO].recoverProtocol(id).unsafeRunSync() === Some(dummyProtocol)
-    }
-  }
-
 }
+ */

--- a/modules/server/src/test/scala/higherkindness/compendium/db/DBServiceStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/db/DBServiceStub.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.compendium.db
+
+import cats.effect.IO
+import higherkindness.compendium.models.Protocol
+
+class DBServiceStub extends DBService[IO] {
+  override def addProtocol(id: String, protocol: Protocol): IO[Unit] = IO.unit
+}

--- a/modules/server/src/test/scala/higherkindness/compendium/http/RootServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/http/RootServiceSpec.scala
@@ -31,7 +31,7 @@ object RootServiceSpec extends Specification with ScalaCheck {
 
   sequential
 
-  private val dummyProtocol: Protocol = Protocol("", "")
+  private val dummyProtocol: Protocol = Protocol("")
 
   def compendiumServiceIO(protocolOpt: Option[Protocol], identifier: Int) =
     new CompendiumService[IO] {

--- a/modules/server/src/test/scala/higherkindness/compendium/http/RootServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/http/RootServiceSpec.scala
@@ -24,7 +24,7 @@ import org.http4s.dsl.io._
 import org.http4s.circe.CirceEntityCodec._
 import Encoders._
 import Decoders._
-import higherkindness.compendium.core.CompendiumService
+import higherkindness.compendium.core.{CompendiumService, CompendiumServiceStub}
 import org.specs2.ScalaCheck
 import org.scalacheck.Gen
 
@@ -34,16 +34,9 @@ object RootServiceSpec extends Specification with ScalaCheck {
 
   private val dummyProtocol: Protocol = Protocol("")
 
-  def compendiumServiceIO(protocolOpt: Option[Protocol]) =
-    new CompendiumService[IO] {
-      override def storeProtocol(id: String, protocol: Protocol): IO[Unit] = IO.unit
-
-      override def recoverProtocol(id: String): IO[Option[Protocol]] = IO(protocolOpt)
-    }
-
   "GET /v0/protocol/id" >> {
     "If successs returns a valid protocol and status code" >> {
-      implicit val compendiumService = compendiumServiceIO(Some(dummyProtocol))
+      implicit val compendiumService = new CompendiumServiceStub(Some(dummyProtocol))
 
       val request = Request[IO](
         uri = Uri(
@@ -59,7 +52,7 @@ object RootServiceSpec extends Specification with ScalaCheck {
     }
 
     "If protocol not found returns not found" >> {
-      implicit val compendiumService = compendiumServiceIO(None)
+      implicit val compendiumService = new CompendiumServiceStub(None)
 
       val request = Request[IO](
         uri = Uri(
@@ -96,7 +89,7 @@ object RootServiceSpec extends Specification with ScalaCheck {
     }
 
     "If protocol is valid returns OK and the location in the headers" >> prop { id: String =>
-      implicit val compendiumService = compendiumServiceIO(None)
+      implicit val compendiumService = new CompendiumServiceStub(None)
 
       val request: Request[IO] = Request[IO](
         uri = Uri(

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/StorageStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/StorageStub.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.compendium.storage
+
+import cats.effect.IO
+import cats.syntax.apply._
+import higherkindness.compendium.models.Protocol
+import org.specs2.matcher.Matchers
+
+class StorageStub(val proto: Option[Protocol], val identifier: String)
+    extends Storage[IO]
+    with Matchers {
+  override def store(id: String, protocol: Protocol): IO[Unit] =
+    IO {
+      proto === Some(protocol)
+      id === identifier
+    } *> IO.unit
+
+  override def recover(id: String): IO[Option[Protocol]] =
+    if (id == identifier) IO(proto) else IO(None)
+
+  override def checkIfExists(id: String): IO[Boolean] =
+    if (id == identifier) IO(false) else IO(true)
+}


### PR DESCRIPTION
- [x] Update `Protocol` model
- [x] Use `String` as protocol id
- [x] Update API to use new protocol id
- [x] Update returned HTTP Status
- [x] Tests

Close #20 - Using `String` instead of `Int` for identifiers