### PR TITLE
Minor refactor for DBService File System implementation

### DIFF
--- a/modules/server/src/main/scala/higherkindness/compendium/Main.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/Main.scala
@@ -20,7 +20,7 @@ import cats.effect._
 import cats.syntax.functor._
 import fs2.Stream
 import higherkindness.compendium.core.{CompendiumService, ProtocolUtils}
-import higherkindness.compendium.db.{DBService, DBServiceStorage}
+import higherkindness.compendium.db.{DBService, FileDBService}
 import higherkindness.compendium.http.RootService
 import higherkindness.compendium.models.CompendiumConfig
 import higherkindness.compendium.storage.{FileStorage, Storage}
@@ -37,7 +37,7 @@ object CompendiumStreamApp {
     for {
       conf <- Stream.eval(Effect[F].delay(pureconfig.loadConfigOrThrow[CompendiumConfig]))
       implicit0(storage: Storage[F])                     = FileStorage.impl[F](conf.storage)
-      implicit0(dbService: DBService[F])                 = DBServiceStorage.impl[F]
+      implicit0(dbService: DBService[F])                 = FileDBService.impl[F]
       implicit0(utils: ProtocolUtils[F])                 = ProtocolUtils.impl[F]()
       implicit0(compendiumService: CompendiumService[F]) = CompendiumService.impl[F]
       service                                            = RootService.rootRouteService

--- a/modules/server/src/main/scala/higherkindness/compendium/db/FileDBService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/db/FileDBService.scala
@@ -23,17 +23,16 @@ import higherkindness.compendium.models.Protocol
 import higherkindness.compendium.models.ProtocolAlreadyExists
 import higherkindness.compendium.storage.Storage
 
-object DBServiceStorage {
+object FileDBService {
 
   def impl[F[_]: Sync: Storage]: DBService[F] =
     new DBService[F] {
-
       override def addProtocol(id: String, protocol: Protocol): F[Unit] =
         for {
           exists <- Storage[F].checkIfExists(id)
           _ <- exists.fold(
             Sync[F].raiseError(new ProtocolAlreadyExists(s"Protocol with id ${id} already exists")),
-            Storage[F].store(id, protocol))
+            Sync[F].unit)
         } yield ()
     }
 }

--- a/modules/server/src/test/scala/higherkindness/compendium/db/FileDBServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/db/FileDBServiceSpec.scala
@@ -22,7 +22,7 @@ import higherkindness.compendium.storage.StorageStub
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 
-object DBServiceStorageSpec extends Specification with ScalaCheck {
+object FileDBServiceSPec extends Specification with ScalaCheck {
 
   sequential
 
@@ -32,7 +32,7 @@ object DBServiceStorageSpec extends Specification with ScalaCheck {
     "If the protocol doesn't exists we store it" >> prop { id: String =>
       implicit val storage = new StorageStub(Some(dummyProtocol), id)
 
-      DBServiceStorage.impl[IO].addProtocol(id, dummyProtocol).map(_ => success).unsafeRunSync()
+      FileDBService.impl[IO].addProtocol(id, dummyProtocol).map(_ => success).unsafeRunSync()
     }
 
     "If the protocol exists we raised an error" >> prop { id: String =>
@@ -40,7 +40,7 @@ object DBServiceStorageSpec extends Specification with ScalaCheck {
         override def checkIfExists(id: String): IO[Boolean] = IO(true)
       }
 
-      DBServiceStorage.impl[IO].addProtocol(id, dummyProtocol).unsafeRunSync must
+      FileDBService.impl[IO].addProtocol(id, dummyProtocol).unsafeRunSync must
         throwA[ProtocolAlreadyExists]
     }
   }


### PR DESCRIPTION
This PR refactors DBService implementation using the file system.
- [x] Rename to `FileDBService` to homogenize for future implementations (i.e.: `PGDBService`).
- [x] Do not persist the protocol in `FileDBService`.