### PR TITLE
fix minor things

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,8 @@ lazy val docs = project
         Map("title" -> "changelog", "section" -> "changelog", "position" -> "99")
       )
     ),
+    scalacOptions in console ~= filterConsoleScalacOptions,
+    scalacOptions in doc ~= filterConsoleScalacOptions,
     scalacOptions in Tut ~= filterConsoleScalacOptions,
     scalacOptions in Tut += "-language:postfixOps"
   )
@@ -163,6 +165,7 @@ lazy val clientSettings = Seq(
 
 lazy val serverSettings = Seq(
   libraryDependencies ++= Seq(
+    "org.slf4j" % "slf4j-simple" % "1.7.26",
     "io.chrisdavenport" %% "cats-scalacheck" % V.catsScalacheck % Test
   )
 )

--- a/modules/client/src/main/scala/higherkindness/compendium/CompendiumClient.scala
+++ b/modules/client/src/main/scala/higherkindness/compendium/CompendiumClient.scala
@@ -50,7 +50,7 @@ object CompendiumClient {
   implicit def impl[F[_]: Sync: InterpTrans](
       implicit clientConfig: CompendiumConfig): CompendiumClient[F] = {
 
-    val baseUrl: String = s"https://${clientConfig.http.host}:${clientConfig.http.port}"
+    val baseUrl: String = s"${clientConfig.http.host}:${clientConfig.http.port}"
 
     new CompendiumClient[F] {
 


### PR DESCRIPTION
This PR:

- removes crazy warnings from console
- adds slf4j simple to get logs in the server
- allows the user to specify the full server URL (including protocol) from config.

I've tested with the following and works correctly:

```scala
import higherkindness.compendium.models._
import higherkindness.compendium._
import cats.effect.IO
import hammock._
import hammock.asynchttpclient._

implicit val clientConfig: CompendiumConfig = CompendiumConfig(HttpConfig("localhost", 8080))

implicit val interpreter: InterpTrans[IO] = new AsyncHttpClientInterpreter[IO]

val client = CompendiumClient.impl[IO]

val raw = """
     {"namespace": "correct.avro",
     "type": "record",
     "name": "User",
     "fields": [
         {"name": "name", "type": "string"},
         {"name": "age",  "type": "int"},
         {"name": "address", "type": ["string", "null"]}
     ]
    }"""
val protocol = Protocol(raw)

val identifier = client.storeProtocol("identifier", protocol)

println(identifier.unsafeRunSync())
```