### PR TITLE
Refactor models structure

### DIFF
--- a/modules/client/src/main/scala/higherkindness/compendium/CompendiumClient.scala
+++ b/modules/client/src/main/scala/higherkindness/compendium/CompendiumClient.scala
@@ -20,9 +20,8 @@ import cats.effect.IO
 import cats.free.Free
 import hammock._
 import hammock.circe.implicits._
-import higherkindness.compendium.http.Encoders._
-import higherkindness.compendium.http.Decoders._
 import higherkindness.compendium.models._
+import higherkindness.compendium.models.config._
 
 trait CompendiumClient {
 

--- a/modules/client/src/main/scala/higherkindness/compendium/Test.scala
+++ b/modules/client/src/main/scala/higherkindness/compendium/Test.scala
@@ -17,7 +17,8 @@
 package higherkindness.compendium
 
 import hammock.asynchttpclient.AsyncHttpClientInterpreter._
-import higherkindness.compendium.models.{CompendiumConfig, Protocol}
+import higherkindness.compendium.models._
+import higherkindness.compendium.models.config._
 import pureconfig.generic.auto._
 
 object Test extends App {

--- a/modules/client/src/main/scala/higherkindness/compendium/models/config/CompendiumConfig.scala
+++ b/modules/client/src/main/scala/higherkindness/compendium/models/config/CompendiumConfig.scala
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-package higherkindness.compendium.models
+package higherkindness.compendium.models.config
 
 final case class CompendiumConfig(http: HttpConfig)

--- a/modules/client/src/test/scala/higherkindness/compendium/CompendiumClientSpec.scala
+++ b/modules/client/src/test/scala/higherkindness/compendium/CompendiumClientSpec.scala
@@ -20,13 +20,12 @@ import cats.effect.{IO, Sync}
 import cats.~>
 import cats.effect._
 import hammock.{HttpF, HttpRequest, InterpTrans, Post}
-import higherkindness.compendium.models.{CompendiumConfig, ErrorResponse, Protocol, Target}
+import higherkindness.compendium.models._
+import higherkindness.compendium.models.config._
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 import pureconfig.generic.auto._
 import hammock._
-import higherkindness.compendium.http._
-import Encoders._
 import io.circe.syntax._
 
 object CompendiumClientSpec extends Specification with ScalaCheck {

--- a/modules/common/src/main/scala/higherkindness/compendium/models/ErrorResponse.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models/ErrorResponse.scala
@@ -16,4 +16,12 @@
 
 package higherkindness.compendium.models
 
-final case class HttpConfig(host: String, port: Int)
+import io.circe._
+import io.circe.generic.semiauto._
+
+final case class ErrorResponse(message: String)
+
+object ErrorResponse {
+  implicit val decoder: Decoder[ErrorResponse] = deriveDecoder[ErrorResponse]
+  implicit val encoder: Encoder[ErrorResponse] = deriveEncoder[ErrorResponse]
+}

--- a/modules/common/src/main/scala/higherkindness/compendium/models/Protocol.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models/Protocol.scala
@@ -16,16 +16,12 @@
 
 package higherkindness.compendium.models
 
-import enumeratum._
+import io.circe._
+import io.circe.generic.semiauto._
 
 final case class Protocol(raw: String)
-final case class ErrorResponse(message: String)
 
-sealed trait Target extends EnumEntry
-
-object Target extends Enum[Target] {
-
-  val values = findValues
-
-  case object Scala extends Target
+object Protocol {
+  implicit val decoder: Decoder[Protocol] = deriveDecoder[Protocol]
+  implicit val encoder: Encoder[Protocol] = deriveEncoder[Protocol]
 }

--- a/modules/common/src/main/scala/higherkindness/compendium/models/Target.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models/Target.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.compendium.models
+
+import enumeratum._
+
+sealed trait Target extends EnumEntry
+
+object Target extends Enum[Target] {
+
+  val values = findValues
+
+  case object Scala extends Target
+}

--- a/modules/common/src/main/scala/higherkindness/compendium/models/config/HttpConfig.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models/config/HttpConfig.scala
@@ -14,20 +14,6 @@
  * limitations under the License.
  */
 
-package higherkindness.compendium.http
+package higherkindness.compendium.models.config
 
-import higherkindness.compendium.models.{ErrorResponse, Protocol}
-import io.circe.{Decoder, Encoder}
-import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-
-object Decoders {
-
-  implicit val protocolDecoder: Decoder[Protocol]           = deriveDecoder[Protocol]
-  implicit val errorResponseDecoder: Decoder[ErrorResponse] = deriveDecoder[ErrorResponse]
-}
-
-object Encoders {
-
-  implicit val protocolEnconder: Encoder[Protocol]          = deriveEncoder[Protocol]
-  implicit val errorResponseEncoder: Encoder[ErrorResponse] = deriveEncoder[ErrorResponse]
-}
+final case class HttpConfig(host: String, port: Int)

--- a/modules/server/src/main/scala/higherkindness/compendium/CompendiumServerStream.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/CompendiumServerStream.scala
@@ -18,7 +18,7 @@ package higherkindness.compendium
 
 import cats.effect._
 import fs2.Stream
-import higherkindness.compendium.models.HttpConfig
+import higherkindness.compendium.models.config._
 import org.http4s._
 import org.http4s.implicits._
 import org.http4s.server.blaze.BlazeServerBuilder

--- a/modules/server/src/main/scala/higherkindness/compendium/Main.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/Main.scala
@@ -22,12 +22,12 @@ import doobie.hikari.HikariTransactor
 import doobie.util.ExecutionContexts
 import doobie.util.transactor.Transactor
 import fs2.Stream
-import higherkindness.compendium.core.{CompendiumService, ProtocolUtils}
-import higherkindness.compendium.db.{DBService, PgDBService}
-import higherkindness.compendium.http.{HealthService, RootService}
+import higherkindness.compendium.core._
+import higherkindness.compendium.db._
+import higherkindness.compendium.http._
 import higherkindness.compendium.migrations.Migrations
-import higherkindness.compendium.models._
-import higherkindness.compendium.storage.{FileStorage, Storage}
+import higherkindness.compendium.models.config._
+import higherkindness.compendium.storage._
 import org.http4s.server.Router
 import pureconfig.generic.auto._
 

--- a/modules/server/src/main/scala/higherkindness/compendium/http/HealthService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/HealthService.scala
@@ -19,12 +19,10 @@ package higherkindness.compendium.http
 import buildinfo.BuildInfo
 import cats.effect.Sync
 import cats.syntax.flatMap._
-import io.circe.syntax._
-import org.http4s.circe.CirceEntityCodec._
 import higherkindness.compendium.db.DBService
 import higherkindness.compendium.models.HealthResponse
-import higherkindness.compendium.models.Encoders._
 import org.http4s.HttpRoutes
+import org.http4s.circe.CirceEntityEncoder._
 import org.http4s.dsl.Http4sDsl
 
 object HealthService {
@@ -39,7 +37,7 @@ object HealthService {
         DBService[F]
           .ping()
           .ifM(
-            Ok(HealthResponse("pass", BuildInfo.name, BuildInfo.version).asJson),
+            Ok(HealthResponse("pass", BuildInfo.name, BuildInfo.version)),
             InternalServerError()
           )
     }

--- a/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
@@ -19,16 +19,14 @@ package higherkindness.compendium.http
 import cats.effect.Sync
 import cats.syntax.flatMap._
 import cats.syntax.functor._
-import org.http4s.circe.CirceEntityCodec._
-import higherkindness.compendium.models._
-import org.http4s.dsl.Http4sDsl
-import Decoders._
-import Encoders._
 import higherkindness.compendium.core.CompendiumService
 import higherkindness.compendium.http.QueryParams.TargetQueryParam
-import org.http4s.HttpRoutes
-import org.http4s.headers.Location
+import higherkindness.compendium.models._
 import mouse.all._
+import org.http4s.HttpRoutes
+import org.http4s.circe.CirceEntityCodec._
+import org.http4s.dsl.Http4sDsl
+import org.http4s.headers.Location
 
 object RootService {
 

--- a/modules/server/src/main/scala/higherkindness/compendium/migrations/Migrations.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/migrations/Migrations.scala
@@ -18,7 +18,7 @@ package higherkindness.compendium.migrations
 
 import cats.effect.Sync
 import cats.implicits._
-import higherkindness.compendium.models.PostgresConfig
+import higherkindness.compendium.models.config.PostgresConfig
 import org.flywaydb.core.Flyway
 
 object Migrations {

--- a/modules/server/src/main/scala/higherkindness/compendium/models/HealthResponse.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/models/HealthResponse.scala
@@ -14,24 +14,14 @@
  * limitations under the License.
  */
 
-package higherkindness.compendium
+package higherkindness.compendium.models
 
-import higherkindness.compendium.models.Protocol
-import org.scalacheck.{Arbitrary, Gen}
+import io.circe._
+import io.circe.generic.semiauto._
 
-trait CompendiumArbitrary {
+final case class HealthResponse(status: String, serviceId: String, version: String)
 
-  implicit val protocolArbitrary: Arbitrary[Protocol] = Arbitrary {
-    Gen.alphaNumStr.map(Protocol.apply)
-  }
-
-  implicit val differentIdentifiersArb: Arbitrary[DifferentIdentifiers] = Arbitrary {
-    for {
-      id1 <- Gen.alphaStr
-      id2 <- Gen.alphaStr.suchThat(id => !id.equalsIgnoreCase(id1))
-    } yield DifferentIdentifiers(id1, id2)
-  }
-
+object HealthResponse {
+  implicit val decoder: Decoder[HealthResponse] = deriveDecoder[HealthResponse]
+  implicit val encoder: Encoder[HealthResponse] = deriveEncoder[HealthResponse]
 }
-
-object CompendiumArbitrary extends CompendiumArbitrary

--- a/modules/server/src/main/scala/higherkindness/compendium/models/config/CompendiumConfig.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/models/config/CompendiumConfig.scala
@@ -14,23 +14,11 @@
  * limitations under the License.
  */
 
-package higherkindness.compendium.models
+package higherkindness.compendium.models.config
 
 import com.zaxxer.hikari.HikariConfig
-import io.circe.{Decoder, Encoder}
-import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 
 import scala.concurrent.duration.FiniteDuration
-
-object Decoders {
-  implicit val healthResponseDecoder: Decoder[HealthResponse] = deriveDecoder[HealthResponse]
-}
-
-object Encoders {
-  implicit val healthResponseEncoder: Encoder[HealthResponse] = deriveEncoder[HealthResponse]
-}
-
-final case class HealthResponse(status: String, serviceID: String, version: String)
 
 final case class CompendiumConfig(
     http: HttpConfig,

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
@@ -19,9 +19,9 @@ package higherkindness.compendium.storage
 import java.io.{File, PrintWriter}
 
 import cats.effect.Sync
-import cats.syntax.functor._
-import cats.syntax.flatMap._
-import higherkindness.compendium.models.{Protocol, StorageConfig}
+import cats.implicits._
+import higherkindness.compendium.models.Protocol
+import higherkindness.compendium.models.config.StorageConfig
 
 object FileStorage {
 

--- a/modules/server/src/test/scala/higherkindness/compendium/db/PGHelper.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/db/PGHelper.scala
@@ -20,7 +20,7 @@ import cats.effect._
 import com.dimafeng.testcontainers.PostgreSQLContainer
 import doobie.util.transactor.Transactor
 import higherkindness.compendium.migrations.Migrations
-import higherkindness.compendium.models.PostgresConfig
+import higherkindness.compendium.models.config.PostgresConfig
 import io.chrisdavenport.testcontainersspecs2.ForAllTestContainer
 import org.specs2.mutable.Specification
 

--- a/modules/server/src/test/scala/higherkindness/compendium/http/HealthServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/http/HealthServiceSpec.scala
@@ -19,13 +19,12 @@ package higherkindness.compendium.http
 import buildinfo.BuildInfo
 import cats.effect.IO
 import higherkindness.compendium.db.DBServiceStub
-import higherkindness.compendium.models.Decoders._
 import higherkindness.compendium.models.HealthResponse
-import org.specs2.ScalaCheck
-import org.specs2.mutable.Specification
-import org.http4s.{Method, Request, Response, Status, Uri}
 import org.http4s.circe.CirceEntityCodec._
 import org.http4s.implicits._
+import org.http4s.{Method, Request, Response, Status, Uri}
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
 
 object HealthServiceSpec extends Specification with ScalaCheck {
 

--- a/modules/server/src/test/scala/higherkindness/compendium/http/RootServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/http/RootServiceSpec.scala
@@ -17,16 +17,14 @@
 package higherkindness.compendium.http
 
 import cats.effect.IO
+import higherkindness.compendium.core.CompendiumServiceStub
 import higherkindness.compendium.models._
-import org.specs2.mutable.Specification
-import org.http4s.{Method, Request, Response, Status, Uri}
 import org.http4s.circe.CirceEntityCodec._
 import org.http4s.implicits._
-import Encoders._
-import Decoders._
-import higherkindness.compendium.core.CompendiumServiceStub
-import org.specs2.ScalaCheck
+import org.http4s.{Method, Request, Response, Status, Uri}
 import org.scalacheck.Gen
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
 
 object RootServiceSpec extends Specification with ScalaCheck {
 

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/FileStorageSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/FileStorageSpec.scala
@@ -20,7 +20,8 @@ import java.io.File
 
 import cats.effect.IO
 import higherkindness.compendium.CompendiumArbitrary._
-import higherkindness.compendium.models.{Protocol, StorageConfig}
+import higherkindness.compendium.models.Protocol
+import higherkindness.compendium.models.config.StorageConfig
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 import org.specs2.specification.{AfterEach, BeforeAfterAll}


### PR DESCRIPTION
- Move configurations under `models/config/` package.
- Move `Encoders` and `Decoders` under companion objects.
- Move models to its own file in most of the cases.
- Sort imports