### PR TITLE
Add refined and protocol identifier type restrictions to compendium-server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val V = new {
   val hammock: String          = "0.9.2"
   val doobie: String           = "0.7.0"
   val flyway: String           = "5.2.4"
+  val refined: String          = "0.9.7"
 }
 
 lazy val root = project
@@ -183,6 +184,8 @@ lazy val serverSettings = Seq(
   parallelExecution in Test := false,
   libraryDependencies ++= Seq(
     "org.slf4j" % "slf4j-simple" % "1.7.26",
+    "eu.timepit" %% "refined"            % V.refined,
+    "eu.timepit" %% "refined-scalacheck" % V.refined,
     "io.chrisdavenport" %% "cats-scalacheck" % V.catsScalacheck % Test
   )
 )

--- a/modules/common/src/main/scala/higherkindness/compendium/models/errors.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models/errors.scala
@@ -17,5 +17,5 @@
 package higherkindness.compendium.models
 
 final case class ProtocolIdentifierError(message: String) extends Exception(message)
-class SchemaError(message: String)                        extends Exception(message)
-class UnknownError(message: String)                       extends Exception(message)
+final case class SchemaError(message: String)             extends Exception(message)
+final case class UnknownError(message: String)            extends Exception(message)

--- a/modules/common/src/main/scala/higherkindness/compendium/models/errors.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models/errors.scala
@@ -16,5 +16,6 @@
 
 package higherkindness.compendium.models
 
-class SchemaError(message: String)  extends Exception(message)
-class UnknownError(message: String) extends Exception(message)
+final case class ProtocolIdentifierError(message: String) extends Exception(message)
+class SchemaError(message: String)                        extends Exception(message)
+class UnknownError(message: String)                       extends Exception(message)

--- a/modules/server/src/main/scala/higherkindness/compendium/core/refinements.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/core/refinements.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.compendium.core
+
+import cats.effect.Sync
+import cats.syntax.either._
+import eu.timepit.refined._
+import eu.timepit.refined.api.{Refined, RefinedTypeOps}
+import eu.timepit.refined.boolean.{And, AnyOf}
+import eu.timepit.refined.char.LetterOrDigit
+import eu.timepit.refined.collection.{Forall, MaxSize}
+import eu.timepit.refined.generic.Equal
+import shapeless.{::, HNil}
+
+object refinements {
+
+  // Protocol identifier size (based on filename size limits)
+  type MaxProtocolIdSize = MaxSize[W.`255`.T]
+  type ValidProtocolIdChars =
+    Forall[AnyOf[LetterOrDigit :: Equal[W.`'-'`.T] :: Equal[W.`'.'`.T] :: HNil]]
+  type ProtocolIdConstraints = And[MaxProtocolIdSize, ValidProtocolIdChars]
+
+  type ProtocolId = String Refined ProtocolIdConstraints
+
+  object ProtocolId extends RefinedTypeOps[ProtocolId, String]
+
+  def validateProtocolId[F[_]: Sync](value: String)(
+      liftIntoThrowable: String => Throwable): F[ProtocolId] = {
+    val refinement = refineV[ProtocolIdConstraints](value).leftMap(liftIntoThrowable)
+
+    Sync[F].fromEither(refinement)
+  }
+}

--- a/modules/server/src/main/scala/higherkindness/compendium/db/DBService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/db/DBService.scala
@@ -16,9 +16,11 @@
 
 package higherkindness.compendium.db
 
+import higherkindness.compendium.core.refinements.ProtocolId
+
 trait DBService[F[_]] {
-  def upsertProtocol(id: String): F[Unit]
-  def existsProtocol(id: String): F[Boolean]
+  def upsertProtocol(id: ProtocolId): F[Unit]
+  def existsProtocol(id: ProtocolId): F[Boolean]
   def ping(): F[Boolean]
 }
 

--- a/modules/server/src/main/scala/higherkindness/compendium/db/PgDBService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/db/PgDBService.scala
@@ -20,6 +20,7 @@ import cats.effect.Async
 import cats.implicits._
 import doobie.util.transactor.Transactor
 import doobie.implicits._
+import higherkindness.compendium.core.refinements.ProtocolId
 import higherkindness.compendium.db.queries.Queries
 
 object PgDBService {
@@ -27,11 +28,11 @@ object PgDBService {
   def impl[F[_]: Async](xa: Transactor[F]): DBService[F] =
     new DBService[F] {
 
-      override def upsertProtocol(id: String): F[Unit] =
-        Queries.upsertProtocolIdQ(id).run.void.transact(xa)
+      override def upsertProtocol(id: ProtocolId): F[Unit] =
+        Queries.upsertProtocolIdQ(id.value).run.void.transact(xa)
 
-      override def existsProtocol(id: String): F[Boolean] =
-        Queries.checkIfExistsQ(id).unique.transact(xa)
+      override def existsProtocol(id: ProtocolId): F[Boolean] =
+        Queries.checkIfExistsQ(id.value).unique.transact(xa)
 
       override def ping(): F[Boolean] = Queries.checkConnection().unique.transact(xa)
     }

--- a/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
@@ -27,6 +27,7 @@ import org.http4s.HttpRoutes
 import org.http4s.circe.CirceEntityCodec._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Location
+import higherkindness.compendium.core.refinements._
 
 object RootService {
 
@@ -39,22 +40,28 @@ object RootService {
       case req @ POST -> Root / "protocol" / id =>
         Sync[F].recoverWith(
           for {
-            protocol <- req.as[Protocol]
-            exists   <- CompendiumService[F].existsProtocol(id)
-            _        <- CompendiumService[F].storeProtocol(id, protocol)
-            resp     <- exists.fold(Ok(), Created())
+            protocol   <- req.as[Protocol]
+            protocolId <- validateProtocolId(id)(ProtocolIdentifierError)
+            exists     <- CompendiumService[F].existsProtocol(protocolId)
+            _          <- CompendiumService[F].storeProtocol(protocolId, protocol)
+            resp       <- exists.fold(Ok(), Created())
           } yield resp.putHeaders(Location(req.uri.withPath(s"${req.uri.path}")))
         ) {
           case e: org.apache.avro.SchemaParseException => BadRequest(ErrorResponse(e.getMessage))
           case e: org.http4s.InvalidMessageBodyFailure => BadRequest(ErrorResponse(e.getMessage))
-          case _ => InternalServerError()
+          case idError: ProtocolIdentifierError        => BadRequest(ErrorResponse(idError.message))
+          case _                                       => InternalServerError()
         }
 
       case GET -> Root / "protocol" / id =>
-        for {
-          protocol <- CompendiumService[F].recoverProtocol(id)
-          resp     <- protocol.fold(NotFound())(Ok(_))
-        } yield resp
+        Sync[F].recoverWith(for {
+          protocolId <- validateProtocolId(id)(ProtocolIdentifierError)
+          protocol   <- CompendiumService[F].recoverProtocol(protocolId)
+          resp       <- protocol.fold(NotFound())(Ok(_))
+        } yield resp) {
+          case idError: ProtocolIdentifierError => BadRequest(ErrorResponse(idError.message))
+          case _                                => InternalServerError()
+        }
 
       case GET -> Root / "protocol" / _ / "generate" :? TargetQueryParam(_) =>
         NotImplemented()

--- a/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
@@ -17,9 +17,11 @@
 package higherkindness.compendium.http
 
 import cats.effect.Sync
+import cats.syntax.applicativeError._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import higherkindness.compendium.core.CompendiumService
+import higherkindness.compendium.core.refinements._
 import higherkindness.compendium.http.QueryParams.TargetQueryParam
 import higherkindness.compendium.models._
 import mouse.all._
@@ -27,7 +29,6 @@ import org.http4s.HttpRoutes
 import org.http4s.circe.CirceEntityCodec._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Location
-import higherkindness.compendium.core.refinements._
 
 object RootService {
 
@@ -38,15 +39,13 @@ object RootService {
 
     HttpRoutes.of[F] {
       case req @ POST -> Root / "protocol" / id =>
-        Sync[F].recoverWith(
-          for {
-            protocol   <- req.as[Protocol]
-            protocolId <- validateProtocolId(id)(ProtocolIdentifierError)
-            exists     <- CompendiumService[F].existsProtocol(protocolId)
-            _          <- CompendiumService[F].storeProtocol(protocolId, protocol)
-            resp       <- exists.fold(Ok(), Created())
-          } yield resp.putHeaders(Location(req.uri.withPath(s"${req.uri.path}")))
-        ) {
+        (for {
+          protocol   <- req.as[Protocol]
+          protocolId <- validateProtocolId(id)(ProtocolIdentifierError)
+          exists     <- CompendiumService[F].existsProtocol(protocolId)
+          _          <- CompendiumService[F].storeProtocol(protocolId, protocol)
+          resp       <- exists.fold(Ok(), Created())
+        } yield resp.putHeaders(Location(req.uri.withPath(s"${req.uri.path}")))).recoverWith {
           case e: org.apache.avro.SchemaParseException => BadRequest(ErrorResponse(e.getMessage))
           case e: org.http4s.InvalidMessageBodyFailure => BadRequest(ErrorResponse(e.getMessage))
           case idError: ProtocolIdentifierError        => BadRequest(ErrorResponse(idError.message))
@@ -54,11 +53,11 @@ object RootService {
         }
 
       case GET -> Root / "protocol" / id =>
-        Sync[F].recoverWith(for {
+        (for {
           protocolId <- validateProtocolId(id)(ProtocolIdentifierError)
           protocol   <- CompendiumService[F].recoverProtocol(protocolId)
           resp       <- protocol.fold(NotFound())(Ok(_))
-        } yield resp) {
+        } yield resp).recoverWith {
           case idError: ProtocolIdentifierError => BadRequest(ErrorResponse(idError.message))
           case _                                => InternalServerError()
         }

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
@@ -20,6 +20,7 @@ import java.io.{File, PrintWriter}
 
 import cats.effect.Sync
 import cats.implicits._
+import higherkindness.compendium.core.refinements.ProtocolId
 import higherkindness.compendium.models.Protocol
 import higherkindness.compendium.models.config.StorageConfig
 
@@ -28,7 +29,7 @@ object FileStorage {
   implicit def impl[F[_]: Sync](config: StorageConfig): Storage[F] =
     new Storage[F] {
 
-      override def store(id: String, protocol: Protocol): F[Unit] =
+      override def store(id: ProtocolId, protocol: Protocol): F[Unit] =
         for {
           _ <- Sync[F].catchNonFatal(new File(s"${config.path}${File.separator}$id").mkdirs())
           file <- Sync[F].catchNonFatal(
@@ -40,7 +41,7 @@ object FileStorage {
           }
         } yield ()
 
-      override def recover(id: String): F[Option[Protocol]] =
+      override def recover(id: ProtocolId): F[Option[Protocol]] =
         for {
           filename <- Sync[F].catchNonFatal {
             Option(new File(s"${config.path}${File.separator}$id").listFiles())
@@ -56,7 +57,7 @@ object FileStorage {
           }
         } yield protocol
 
-      override def exists(id: String): F[Boolean] =
+      override def exists(id: ProtocolId): F[Boolean] =
         Sync[F].catchNonFatal(new File(s"${config.path}${File.separator}$id")).map(_.exists)
     }
 

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/Storage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/Storage.scala
@@ -16,13 +16,14 @@
 
 package higherkindness.compendium.storage
 
+import higherkindness.compendium.core.refinements.ProtocolId
 import higherkindness.compendium.models.Protocol
 
 trait Storage[F[_]] {
 
-  def store(id: String, protocol: Protocol): F[Unit]
-  def recover(id: String): F[Option[Protocol]]
-  def exists(id: String): F[Boolean]
+  def store(id: ProtocolId, protocol: Protocol): F[Unit]
+  def recover(id: ProtocolId): F[Option[Protocol]]
+  def exists(id: ProtocolId): F[Boolean]
 }
 
 object Storage {

--- a/modules/server/src/test/scala/higherkindness/compendium/CompendiumArbitrary.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/CompendiumArbitrary.scala
@@ -16,6 +16,7 @@
 
 package higherkindness.compendium
 
+import higherkindness.compendium.core.refinements.ProtocolId
 import higherkindness.compendium.models.Protocol
 import org.scalacheck.{Arbitrary, Gen}
 
@@ -23,6 +24,14 @@ trait CompendiumArbitrary {
 
   implicit val protocolArbitrary: Arbitrary[Protocol] = Arbitrary {
     Gen.alphaNumStr.map(Protocol.apply)
+  }
+
+  implicit val protocolIdArbitrary: Arbitrary[ProtocolId] = Arbitrary {
+    Gen
+      .nonEmptyListOf(
+        Gen.oneOf(Gen.alphaNumChar, Gen.const('-'), Gen.const('.'))
+      )
+      .map(id => ProtocolId.unsafeFrom(id.mkString))
   }
 
   implicit val differentIdentifiersArb: Arbitrary[DifferentIdentifiers] = Arbitrary {

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumRefinementsSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumRefinementsSpec.scala
@@ -35,8 +35,16 @@ object CompendiumRefinementsSpec extends Specification with ScalaCheck {
       refine.unsafeRunSync() === ProtocolId("super-domain.proto")
     }
 
-    "Returns a given exception if refining was unsuccessful" >> {
+    "Returns a given exception if refining was unsuccessful due to invalid chars" >> {
       val rawProtocolId = "invalid_dom@in"
+
+      val refine = validateProtocolId[IO](rawProtocolId)(ProtocolIdentifierError)
+
+      refine.unsafeRunSync() must throwA[ProtocolIdentifierError]
+    }
+
+    "Returns a given exception if refining was unsuccessful due to very long size" >> {
+      val rawProtocolId = (1 to 10).flatMap(_ => 'a' to 'z').mkString
 
       val refine = validateProtocolId[IO](rawProtocolId)(ProtocolIdentifierError)
 

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumRefinementsSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumRefinementsSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.compendium.core
+
+import cats.effect.IO
+import higherkindness.compendium.core.refinements._
+import higherkindness.compendium.models.ProtocolIdentifierError
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+object CompendiumRefinementsSpec extends Specification with ScalaCheck {
+
+  sequential
+
+  "Given a runtime string value to be refined into protocol id" >> {
+    "Returns a valid protocol id if refining was successful" >> {
+      val rawProtocolId = "super-domain.proto"
+
+      val refine = validateProtocolId[IO](rawProtocolId)(new Exception(_))
+
+      refine.unsafeRunSync() === ProtocolId("super-domain.proto")
+    }
+
+    "Returns a given exception if refining was unsuccessful" >> {
+      val rawProtocolId = "invalid_dom@in"
+
+      val refine = validateProtocolId[IO](rawProtocolId)(ProtocolIdentifierError)
+
+      refine.unsafeRunSync() must throwA[ProtocolIdentifierError]
+    }
+  }
+
+}

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceSpec.scala
@@ -17,6 +17,8 @@
 package higherkindness.compendium.core
 
 import cats.effect.IO
+import higherkindness.compendium.CompendiumArbitrary._
+import higherkindness.compendium.core.refinements.ProtocolId
 import higherkindness.compendium.db.DBServiceStub
 import higherkindness.compendium.models.Protocol
 import higherkindness.compendium.storage.StorageStub
@@ -30,7 +32,7 @@ object CompendiumServiceSpec extends Specification with ScalaCheck {
   private val dummyProtocol: Protocol = Protocol("")
 
   "Store protocol" >> {
-    "If it's a valid protocol we store it" >> prop { id: String =>
+    "If it's a valid protocol we store it" >> prop { id: ProtocolId =>
       implicit val dbService     = new DBServiceStub(true)
       implicit val storage       = new StorageStub(Some(dummyProtocol), id)
       implicit val protocolUtils = new ProtocolUtilsStub(dummyProtocol, true)
@@ -38,7 +40,7 @@ object CompendiumServiceSpec extends Specification with ScalaCheck {
       CompendiumService.impl[IO].storeProtocol(id, dummyProtocol).map(_ => success).unsafeRunSync()
     }
 
-    "If it's an invalid protocol we raise an error" >> prop { id: String =>
+    "If it's an invalid protocol we raise an error" >> prop { id: ProtocolId =>
       implicit val dbService     = new DBServiceStub(true)
       implicit val storage       = new StorageStub(Some(dummyProtocol), id)
       implicit val protocolUtils = new ProtocolUtilsStub(dummyProtocol, false)
@@ -51,7 +53,7 @@ object CompendiumServiceSpec extends Specification with ScalaCheck {
   }
 
   "Recover protocol" >> {
-    "Given a identifier we recover the protocol" >> prop { id: String =>
+    "Given a identifier we recover the protocol" >> prop { id: ProtocolId =>
       implicit val dbService     = new DBServiceStub(true)
       implicit val storage       = new StorageStub(Some(dummyProtocol), id)
       implicit val protocolUtils = new ProtocolUtilsStub(dummyProtocol, true)
@@ -61,7 +63,7 @@ object CompendiumServiceSpec extends Specification with ScalaCheck {
   }
 
   "Exists protocol" >> {
-    "Given a identifier we check if a protocol exists" >> prop { id: String =>
+    "Given a identifier we check if a protocol exists" >> prop { id: ProtocolId =>
       implicit val dbService     = new DBServiceStub(true)
       implicit val storage       = new StorageStub(Some(dummyProtocol), id)
       implicit val protocolUtils = new ProtocolUtilsStub(dummyProtocol, true)

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceStub.scala
@@ -17,11 +17,12 @@
 package higherkindness.compendium.core
 
 import cats.effect.IO
+import higherkindness.compendium.core.refinements.ProtocolId
 import higherkindness.compendium.models.Protocol
 
 class CompendiumServiceStub(val protocolOpt: Option[Protocol], exists: Boolean)
     extends CompendiumService[IO] {
-  override def storeProtocol(id: String, protocol: Protocol): IO[Unit] = IO.unit
-  override def recoverProtocol(id: String): IO[Option[Protocol]]       = IO(protocolOpt)
-  override def existsProtocol(protocolId: String): IO[Boolean]         = IO(exists)
+  override def storeProtocol(id: ProtocolId, protocol: Protocol): IO[Unit] = IO.unit
+  override def recoverProtocol(id: ProtocolId): IO[Option[Protocol]]       = IO(protocolOpt)
+  override def existsProtocol(protocolId: ProtocolId): IO[Boolean]         = IO(exists)
 }

--- a/modules/server/src/test/scala/higherkindness/compendium/db/DBServiceStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/db/DBServiceStub.scala
@@ -17,9 +17,10 @@
 package higherkindness.compendium.db
 
 import cats.effect.IO
+import higherkindness.compendium.core.refinements.ProtocolId
 
 class DBServiceStub(val exists: Boolean) extends DBService[IO] {
-  override def upsertProtocol(id: String): IO[Unit]    = IO.unit
-  override def existsProtocol(id: String): IO[Boolean] = IO.pure(exists)
-  override def ping(): IO[Boolean]                     = IO.pure(exists)
+  override def upsertProtocol(id: ProtocolId): IO[Unit]    = IO.unit
+  override def existsProtocol(id: ProtocolId): IO[Boolean] = IO.pure(exists)
+  override def ping(): IO[Boolean]                         = IO.pure(exists)
 }

--- a/modules/server/src/test/scala/higherkindness/compendium/db/PgDBServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/db/PgDBServiceSpec.scala
@@ -18,6 +18,7 @@ package higherkindness.compendium.db
 
 import cats.effect.IO
 import cats.implicits._
+import higherkindness.compendium.core.refinements.ProtocolId
 
 class PgDBServiceSpec extends PGHelper {
 
@@ -25,7 +26,7 @@ class PgDBServiceSpec extends PGHelper {
 
   "Postgres Service" should {
     "insert protocol correctly" in {
-      val id: String = "pId"
+      val id: ProtocolId = ProtocolId("pId")
 
       val result: IO[Boolean] =
         pg.upsertProtocol(id) >> pg.existsProtocol(id)
@@ -35,7 +36,7 @@ class PgDBServiceSpec extends PGHelper {
     }
 
     "update protocol correctly" in {
-      val id: String = "pId2"
+      val id: ProtocolId = ProtocolId("pId2")
 
       val result: IO[Boolean] =
         pg.upsertProtocol(id) >> pg.upsertProtocol(id) >> pg.existsProtocol(id)
@@ -44,11 +45,13 @@ class PgDBServiceSpec extends PGHelper {
     }
 
     "return false when the protocol does not exist" in {
-      pg.existsProtocol("p").unsafeRunSync must ===(false)
+      val id: ProtocolId = ProtocolId("p")
+
+      pg.existsProtocol(id).unsafeRunSync must ===(false)
     }
 
     "return true when the protocol exists" in {
-      val id: String = "pId3"
+      val id: ProtocolId = ProtocolId("pId3")
 
       val result: IO[Boolean] =
         pg.upsertProtocol(id) >> pg.existsProtocol(id)

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/FileStorageSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/FileStorageSpec.scala
@@ -20,6 +20,7 @@ import java.io.File
 
 import cats.effect.IO
 import higherkindness.compendium.CompendiumArbitrary._
+import higherkindness.compendium.core.refinements.ProtocolId
 import higherkindness.compendium.models.Protocol
 import higherkindness.compendium.models.config.StorageConfig
 import org.specs2.ScalaCheck
@@ -57,35 +58,43 @@ object FileStorageSpec extends Specification with ScalaCheck with BeforeAfterAll
 
   "Store a file" >> {
     "Successfully stores a file" >> prop { protocol: Protocol =>
-      val storageProtocolFile = storageProtocol("id")
+      val id = ProtocolId("id")
+
+      val storageProtocolFile = storageProtocol(id.value)
       val io = for {
-        _ <- fileStorage.store("id", protocol)
+        _ <- fileStorage.store(id, protocol)
       } yield storageDirectory.exists && storageProtocolFile.exists
 
       io.unsafeRunSync() should beTrue
     }
 
     "Successfully stores and recovers a file" >> prop { protocol: Protocol =>
+      val id = ProtocolId("id")
+
       val file = for {
-        _ <- fileStorage.store("id", protocol)
-        f <- fileStorage.recover("id")
+        _ <- fileStorage.store(id, protocol)
+        f <- fileStorage.recover(id)
       } yield f
 
       file.unsafeRunSync() should beSome(protocol)
     }
 
     "Returns true if there is a file" >> prop { protocol: Protocol =>
+      val id = ProtocolId("id")
+
       val file = for {
-        _      <- fileStorage.store("id", protocol)
-        exists <- fileStorage.exists("id")
+        _      <- fileStorage.store(id, protocol)
+        exists <- fileStorage.exists(id)
       } yield exists
 
       file.unsafeRunSync() should beTrue
     }
 
     "Returns false if there is no file" >> {
+      val id = ProtocolId("id")
+
       val out = for {
-        exists <- fileStorage.exists("id")
+        exists <- fileStorage.exists(id)
       } yield exists
 
       out.unsafeRunSync() should beFalse

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/StorageStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/StorageStub.scala
@@ -18,21 +18,22 @@ package higherkindness.compendium.storage
 
 import cats.effect.IO
 import cats.syntax.apply._
+import higherkindness.compendium.core.refinements.ProtocolId
 import higherkindness.compendium.models.Protocol
 import org.specs2.matcher.Matchers
 
-class StorageStub(val proto: Option[Protocol], val identifier: String)
+class StorageStub(val proto: Option[Protocol], val identifier: ProtocolId)
     extends Storage[IO]
     with Matchers {
-  override def store(id: String, protocol: Protocol): IO[Unit] =
+  override def store(id: ProtocolId, protocol: Protocol): IO[Unit] =
     IO {
       proto === Some(protocol)
       id === identifier
     } *> IO.unit
 
-  override def recover(id: String): IO[Option[Protocol]] =
+  override def recover(id: ProtocolId): IO[Option[Protocol]] =
     if (id == identifier) IO(proto) else IO(None)
 
-  override def exists(id: String): IO[Boolean] =
+  override def exists(id: ProtocolId): IO[Boolean] =
     IO(id == identifier)
 }


### PR DESCRIPTION
This resolves #36 

I added refined as a compendium-server dependency.

The new protocol identifier type falls through all server layers, which seems ok (please check if these refined types are well located inside `core` package)

A new arbitrary generates `ProtocolId` values for property based tests, and a `PropertyId` `apply` method ensures that discrete values used in other tests are valid.

I'm not sure if adding this refined restriction to compendium-client too is worth it, what do you think?