### PR TITLE
Add common module to aggregate list in root project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val root = project
   .settings(name := "compendium")
   .settings(commonSettings)
   .settings(noPublishSettings)
-  .aggregate(server, client)
+  .aggregate(server, client, common)
 
 lazy val common = project
   .in(file("modules/common"))


### PR DESCRIPTION
Resolves #82 

Isn't this enough to solve this issue? Adding common module to aggregate list in root project, then launching `publishLocal` task, seems to be publishing it to the local cache.

Just double check that it won't mess with the artifacts publishing process.