### PR TITLE
Simple schema versioning

### DIFF
--- a/modules/common/src/main/scala/higherkindness/compendium/models/errors.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models/errors.scala
@@ -16,6 +16,7 @@
 
 package higherkindness.compendium.models
 
-final case class ProtocolIdError(message: String) extends Exception(message)
-final case class SchemaError(message: String)     extends Exception(message)
-final case class UnknownError(message: String)    extends Exception(message)
+final case class ProtocolIdError(message: String)      extends Exception(message)
+final case class ProtocolVersionError(message: String) extends Exception(message)
+final case class SchemaError(message: String)          extends Exception(message)
+final case class UnknownError(message: String)         extends Exception(message)

--- a/modules/common/src/main/scala/higherkindness/compendium/models/errors.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models/errors.scala
@@ -16,6 +16,6 @@
 
 package higherkindness.compendium.models
 
-final case class ProtocolIdentifierError(message: String) extends Exception(message)
-final case class SchemaError(message: String)             extends Exception(message)
-final case class UnknownError(message: String)            extends Exception(message)
+final case class ProtocolIdError(message: String) extends Exception(message)
+final case class SchemaError(message: String)     extends Exception(message)
+final case class UnknownError(message: String)    extends Exception(message)

--- a/modules/server/src/main/resources/db/migration/data/V1__add_protocols_table.sql
+++ b/modules/server/src/main/resources/db/migration/data/V1__add_protocols_table.sql
@@ -1,4 +1,6 @@
 CREATE TABLE protocols (
-    id CHARACTER VARYING(255) PRIMARY KEY,
-    protocol BYTEA
+    id CHARACTER VARYING(255) NOT NULL,
+    version INTEGER NOT NULL,
+    protocol BYTEA,
+    PRIMARY KEY (id, version)
 );

--- a/modules/server/src/main/resources/db/migration/metadata/V1__add_metaprotocols_table.sql
+++ b/modules/server/src/main/resources/db/migration/metadata/V1__add_metaprotocols_table.sql
@@ -2,5 +2,6 @@ CREATE TYPE idl AS ENUM ('avro', 'protobuf', 'mu', 'openapi', 'scala');
 
 CREATE TABLE metaprotocols (
     id VARCHAR PRIMARY KEY,
-    idl_name idl NOT NULL
+    idl_name idl NOT NULL,
+    version INTEGER NOT NULL
 );

--- a/modules/server/src/main/scala/higherkindness/compendium/Main.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/Main.scala
@@ -61,7 +61,7 @@ object CompendiumStreamApp {
   private def initStorage[F[_]: Async: ContextShift](
       storageConfig: StorageConfig): Resource[F, Storage[F]] =
     storageConfig match {
-      case fsc: FileStorageConfig      => Resource.pure(FileStorage.impl[F](fsc))
+      case fsc: FileStorageConfig      => Resource.pure(FileStorage[F](fsc))
       case dbsc: DatabaseStorageConfig => createTransactor(dbsc).map(PgStorage[F])
     }
 

--- a/modules/server/src/main/scala/higherkindness/compendium/core/CompendiumService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/core/CompendiumService.scala
@@ -79,7 +79,7 @@ object CompendiumService {
 
       override def recoverProtocolVersion(
           id: ProtocolId,
-          version: ProtocolVersion): F[Option[FullProtocol]] = getProtocol(id, Option(version))
+          version: ProtocolVersion): F[Option[FullProtocol]] = getProtocol(id, Some(version))
 
       override def existsProtocol(protocolId: ProtocolId): F[Boolean] =
         DBService[F].existsProtocol(protocolId)

--- a/modules/server/src/main/scala/higherkindness/compendium/core/CompendiumService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/core/CompendiumService.scala
@@ -71,7 +71,7 @@ object CompendiumService {
         for {
           _       <- ProtocolUtils[F].validateProtocol(protocol)
           version <- DBService[F].upsertProtocol(id, idlName)
-          _       <- Storage[F].store(id, protocol)
+          _       <- Storage[F].store(id, version, protocol)
         } yield version
 
       override def recoverProtocol(protocolId: ProtocolId): F[Option[FullProtocol]] =

--- a/modules/server/src/main/scala/higherkindness/compendium/core/CompendiumService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/core/CompendiumService.scala
@@ -18,7 +18,7 @@ package higherkindness.compendium.core
 
 import cats.effect.Sync
 import cats.implicits._
-import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
+import higherkindness.compendium.core.refinements._
 import higherkindness.compendium.db.DBService
 import higherkindness.compendium.models._
 import higherkindness.compendium.models.parserModels.{ParserError, ParserResult}

--- a/modules/server/src/main/scala/higherkindness/compendium/core/ProtocolUtils.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/core/ProtocolUtils.scala
@@ -29,7 +29,7 @@ object ProtocolUtils {
 
   private def parser: Schema.Parser = new Schema.Parser()
 
-  def impl[F[_]: Sync](): ProtocolUtils[F] = new ProtocolUtils[F] {
+  def impl[F[_]: Sync]: ProtocolUtils[F] = new ProtocolUtils[F] {
     override def validateProtocol(protocol: Protocol): F[Protocol] =
       if (protocol.raw.trim.isEmpty)
         Sync[F].raiseError(new org.apache.avro.SchemaParseException("Protocol is empty"))

--- a/modules/server/src/main/scala/higherkindness/compendium/core/refinements.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/core/refinements.scala
@@ -16,8 +16,6 @@
 
 package higherkindness.compendium.core
 
-import cats.effect.Sync
-import cats.syntax.either._
 import eu.timepit.refined._
 import eu.timepit.refined.api.{Refined, RefinedTypeOps}
 import eu.timepit.refined.boolean.{And, AnyOf}
@@ -37,11 +35,4 @@ object refinements {
   type ProtocolId = String Refined ProtocolIdConstraints
 
   object ProtocolId extends RefinedTypeOps[ProtocolId, String]
-
-  def validateProtocolId[F[_]: Sync](value: String)(
-      liftIntoThrowable: String => Throwable): F[ProtocolId] = {
-    val refinement = refineV[ProtocolIdConstraints](value).leftMap(liftIntoThrowable)
-
-    Sync[F].fromEither(refinement)
-  }
 }

--- a/modules/server/src/main/scala/higherkindness/compendium/core/refinements.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/core/refinements.scala
@@ -16,12 +16,15 @@
 
 package higherkindness.compendium.core
 
+import cats.effect.Sync
+import cats.syntax.either._
 import eu.timepit.refined._
 import eu.timepit.refined.api.{Refined, RefinedTypeOps}
 import eu.timepit.refined.boolean.{And, AnyOf}
 import eu.timepit.refined.char.LetterOrDigit
 import eu.timepit.refined.collection.{Forall, MaxSize}
 import eu.timepit.refined.generic.Equal
+import higherkindness.compendium.models.ProtocolIdError
 import shapeless.{::, HNil}
 
 object refinements {
@@ -34,5 +37,8 @@ object refinements {
 
   type ProtocolId = String Refined ProtocolIdConstraints
 
-  object ProtocolId extends RefinedTypeOps[ProtocolId, String]
+  object ProtocolId extends RefinedTypeOps[ProtocolId, String] {
+    def parseOrRaise[F[_]: Sync](id: String): F[ProtocolId] =
+      Sync[F].fromEither(ProtocolId.from(id).leftMap(ProtocolIdError))
+  }
 }

--- a/modules/server/src/main/scala/higherkindness/compendium/core/refinements.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/core/refinements.scala
@@ -17,14 +17,15 @@
 package higherkindness.compendium.core
 
 import cats.effect.Sync
-import cats.syntax.either._
+import cats.syntax.all._
 import eu.timepit.refined._
 import eu.timepit.refined.api.{Refined, RefinedTypeOps}
 import eu.timepit.refined.boolean.{And, AnyOf}
 import eu.timepit.refined.char.LetterOrDigit
 import eu.timepit.refined.collection.{Forall, MaxSize}
 import eu.timepit.refined.generic.Equal
-import higherkindness.compendium.models.ProtocolIdError
+import eu.timepit.refined.numeric.Positive
+import higherkindness.compendium.models.{ProtocolIdError, ProtocolVersionError}
 import shapeless.{::, HNil}
 
 object refinements {
@@ -40,5 +41,16 @@ object refinements {
   object ProtocolId extends RefinedTypeOps[ProtocolId, String] {
     def parseOrRaise[F[_]: Sync](id: String): F[ProtocolId] =
       Sync[F].fromEither(ProtocolId.from(id).leftMap(ProtocolIdError))
+  }
+
+  type ProtocolVersion = Int Refined Positive
+
+  object ProtocolVersion extends RefinedTypeOps[ProtocolVersion, Int] {
+    def parseOrRaise[F[_]: Sync](version: String): F[ProtocolVersion] =
+      for {
+        number <- Sync[F].delay(version.toInt)
+        protoVersion <- Sync[F].fromEither(
+          ProtocolVersion.from(number).leftMap(ProtocolVersionError))
+      } yield protoVersion
   }
 }

--- a/modules/server/src/main/scala/higherkindness/compendium/db/DBService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/db/DBService.scala
@@ -17,10 +17,10 @@
 package higherkindness.compendium.db
 
 import higherkindness.compendium.models.{IdlName, ProtocolMetadata}
-import higherkindness.compendium.core.refinements.ProtocolId
+import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 
 trait DBService[F[_]] {
-  def upsertProtocol(id: ProtocolId, idlName: IdlName): F[Unit]
+  def upsertProtocol(id: ProtocolId, idlName: IdlName): F[ProtocolVersion]
   def existsProtocol(id: ProtocolId): F[Boolean]
   def selectProtocolMetadataById(id: ProtocolId): F[Option[ProtocolMetadata]]
   def ping(): F[Boolean]

--- a/modules/server/src/main/scala/higherkindness/compendium/db/queries/Queries.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/db/queries/Queries.scala
@@ -31,9 +31,10 @@ object Queries {
 
   def upsertProtocolIdQ(id: String, idl_name: String): Update0 =
     sql"""
-          INSERT INTO metaprotocols (id, idl_name)
-          VALUES ($id, $idl_name::idl)
-          ON CONFLICT DO NOTHING
+          INSERT INTO metaprotocols (id, idl_name, version)
+          VALUES ($id, $idl_name::idl, 1)
+          ON CONFLICT (id) DO UPDATE SET version = metaprotocols.version + 1
+          RETURNING version
        """.update
 
   def selectProtocolMetadataById(id: String): Query0[ProtocolMetadata] =

--- a/modules/server/src/main/scala/higherkindness/compendium/db/queries/metas.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/db/queries/metas.scala
@@ -16,10 +16,10 @@
 
 package higherkindness.compendium.db.queries
 
+import cats.instances.int._
 import doobie.util.{Get, Meta, Put}
 import higherkindness.compendium.core.refinements.ProtocolVersion
 import higherkindness.compendium.models.IdlName
-import cats.instances.int._
 
 object metas {
 

--- a/modules/server/src/main/scala/higherkindness/compendium/db/queries/metas.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/db/queries/metas.scala
@@ -16,11 +16,15 @@
 
 package higherkindness.compendium.db.queries
 
-import doobie.util.Meta
+import doobie.util.{Get, Meta, Put}
+import higherkindness.compendium.core.refinements.ProtocolVersion
 import higherkindness.compendium.models.IdlName
+import cats.instances.int._
 
 object metas {
 
   implicit val IdlNamesMeta: Meta[IdlName] = Meta[String].timap(IdlName.withName)(_.entryName)
 
+  implicit val protocolVersion: Put[ProtocolVersion] = Put[Int].contramap(_.value)
+  implicit val protocolIdGet: Get[ProtocolVersion]   = Get[Int].temap(ProtocolVersion.from)
 }

--- a/modules/server/src/main/scala/higherkindness/compendium/http/QueryParams.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/QueryParams.scala
@@ -16,9 +16,10 @@
 
 package higherkindness.compendium.http
 
+import higherkindness.compendium.core.refinements.ProtocolVersion
 import higherkindness.compendium.models.IdlName
 import org.http4s.QueryParamDecoder
-import org.http4s.dsl.impl.QueryParamDecoderMatcher
+import org.http4s.dsl.impl.{OptionalValidatingQueryParamDecoderMatcher, QueryParamDecoderMatcher}
 
 object QueryParams {
 
@@ -27,4 +28,10 @@ object QueryParams {
 
   object TargetParam  extends QueryParamDecoderMatcher[IdlName]("target")
   object IdlNameParam extends QueryParamDecoderMatcher[IdlName]("idlName")
+
+  implicit val versionQueryParamDecoder: QueryParamDecoder[ProtocolVersion] =
+    QueryParamDecoder.fromUnsafeCast[ProtocolVersion](param =>
+      ProtocolVersion.unsafeFrom(param.value.toInt))("ProtocolVersion")
+
+  object ProtoVersion extends OptionalValidatingQueryParamDecoderMatcher[ProtocolVersion]("version")
 }

--- a/modules/server/src/main/scala/higherkindness/compendium/http/QueryParams.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/QueryParams.scala
@@ -23,8 +23,8 @@ import org.http4s.dsl.impl.QueryParamDecoderMatcher
 object QueryParams {
 
   implicit val queryIdlDecoderQueryParam: QueryParamDecoder[IdlName] =
-    QueryParamDecoder[String].map(IdlName.withName)
+    QueryParamDecoder.fromUnsafeCast[IdlName](qp => IdlName.withName(qp.value))("IdlName")
 
-  object TargetQueryParam extends QueryParamDecoderMatcher[IdlName]("target")
-  object IdlQueryParam    extends QueryParamDecoderMatcher[IdlName]("idlName")
+  object TargetParam  extends QueryParamDecoderMatcher[IdlName]("target")
+  object IdlNameParam extends QueryParamDecoderMatcher[IdlName]("idlName")
 }

--- a/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
@@ -22,7 +22,7 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import higherkindness.compendium.core.CompendiumService
 import higherkindness.compendium.core.refinements._
-import higherkindness.compendium.http.QueryParams.{IdlQueryParam, TargetQueryParam}
+import higherkindness.compendium.http.QueryParams.{IdlNameParam, TargetParam}
 import higherkindness.compendium.models._
 import mouse.all._
 import org.http4s.HttpRoutes
@@ -38,36 +38,38 @@ object RootService {
     import f._
 
     HttpRoutes.of[F] {
-      case req @ POST -> Root / "protocol" / ProtocolId(protocolId) :? IdlQueryParam(idlName) =>
+      case req @ POST -> Root / "protocol" / id :? IdlNameParam(idlName) =>
         (for {
-          protocol <- req.as[Protocol]
-          exists   <- CompendiumService[F].existsProtocol(protocolId)
-          _        <- CompendiumService[F].storeProtocol(protocolId, protocol, idlName)
-          resp     <- exists.fold(Ok(), Created())
+          protocol   <- req.as[Protocol]
+          protocolId <- ProtocolId.parseOrRaise(id)
+          exists     <- CompendiumService[F].existsProtocol(protocolId)
+          _          <- CompendiumService[F].storeProtocol(protocolId, protocol, idlName)
+          resp       <- exists.fold(Ok(), Created())
         } yield resp.putHeaders(Location(req.uri.withPath(s"${req.uri.path}")))).recoverWith {
           case e: org.apache.avro.SchemaParseException => BadRequest(ErrorResponse(e.getMessage))
           case e: org.http4s.InvalidMessageBodyFailure => BadRequest(ErrorResponse(e.getMessage))
-          case idError: ProtocolIdentifierError        => BadRequest(ErrorResponse(idError.message))
+          case idError: ProtocolIdError                => BadRequest(idError.message)
           case _                                       => InternalServerError()
         }
 
-      case GET -> Root / "protocol" / ProtocolId(protocolId) =>
+      case GET -> Root / "protocol" / id =>
         (for {
-          protocol <- CompendiumService[F].recoverProtocol(protocolId)
-          resp     <- protocol.fold(NotFound())(mp => Ok(mp.protocol))
+          protocolId <- ProtocolId.parseOrRaise(id)
+          protocol   <- CompendiumService[F].recoverProtocol(protocolId)
+          resp       <- protocol.fold(NotFound())(mp => Ok(mp.protocol))
         } yield resp).recoverWith {
-          case idError: ProtocolIdentifierError => BadRequest(ErrorResponse(idError.message))
-          case _                                => InternalServerError()
+          case idError: ProtocolIdError => BadRequest(idError.message)
+          case _                        => InternalServerError()
         }
 
-      case GET -> Root / "protocol" / ProtocolId(protocolId) / "generate" :? TargetQueryParam(
-            target) =>
+      case GET -> Root / "protocol" / id / "generate" :? TargetParam(target) =>
         (for {
+          protocolId   <- ProtocolId.parseOrRaise(id)
           parserResult <- CompendiumService[F].parseProtocol(protocolId, target)
           resp         <- parserResult.fold(pe => InternalServerError(pe.msg), mp => Ok(mp.protocol.raw))
         } yield resp).recoverWith {
-          case idError: ProtocolIdentifierError => BadRequest(ErrorResponse(idError.message))
-          case _                                => InternalServerError()
+          case idError: ProtocolIdError => BadRequest(idError.message)
+          case _                        => InternalServerError()
         }
     }
   }

--- a/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
@@ -51,8 +51,6 @@ object RootService {
         }
 
       case GET -> Root / "protocol" / id :? ProtoVersion(versionParam) =>
-        println(s"Received ${versionParam}")
-
         def recoverProtocol(id: ProtocolId): F[Option[FullProtocol]] =
           versionParam.fold(CompendiumService[F].recoverProtocol(id)) { versionValidated =>
             val validation =

--- a/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
@@ -65,9 +65,9 @@ object RootService {
           protocol   <- recoverProtocol(protocolId)
           resp       <- protocol.fold(NotFound())(mp => Ok(mp.protocol))
         } yield resp).recoverWith {
-          case id: ProtocolIdError                => BadRequest(ErrorMessage(e.message))
-          case e: ProtocolVersionError            => BadRequest(ErrorMessage(e.message))
-          case _                                  => InternalServerError()
+          case e: ProtocolIdError      => BadRequest(ErrorResponse(e.message))
+          case e: ProtocolVersionError => BadRequest(ErrorResponse(e.message))
+          case _                       => InternalServerError()
         }
 
       case GET -> Root / "protocol" / id / "generate" :? TargetParam(target) =>
@@ -76,8 +76,8 @@ object RootService {
           parserResult <- CompendiumService[F].parseProtocol(protocolId, target)
           resp         <- parserResult.fold(pe => InternalServerError(pe.msg), mp => Ok(mp.protocol.raw))
         } yield resp).recoverWith {
-          case e: ProtocolIdError       => BadRequest(ErrorMessage(e.message))
-          case _                        => InternalServerError()
+          case e: ProtocolIdError => BadRequest(ErrorResponse(e.message))
+          case _                  => InternalServerError()
         }
     }
   }

--- a/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/RootService.scala
@@ -46,7 +46,7 @@ object RootService {
         } yield resp.putHeaders(Location(req.uri.withPath(s"${req.uri.path}")))).recoverWith {
           case e: org.apache.avro.SchemaParseException => BadRequest(ErrorResponse(e.getMessage))
           case e: org.http4s.InvalidMessageBodyFailure => BadRequest(ErrorResponse(e.getMessage))
-          case idError: ProtocolIdError                => BadRequest(idError.message)
+          case e: ProtocolIdError                      => BadRequest(ErrorResponse(e.message))
           case _                                       => InternalServerError()
         }
 
@@ -65,8 +65,8 @@ object RootService {
           protocol   <- recoverProtocol(protocolId)
           resp       <- protocol.fold(NotFound())(mp => Ok(mp.protocol))
         } yield resp).recoverWith {
-          case idError: ProtocolIdError           => BadRequest(idError.message)
-          case versionError: ProtocolVersionError => BadRequest(versionError.message)
+          case id: ProtocolIdError                => BadRequest(ErrorMessage(e.message))
+          case e: ProtocolVersionError            => BadRequest(ErrorMessage(e.message))
           case _                                  => InternalServerError()
         }
 
@@ -76,7 +76,7 @@ object RootService {
           parserResult <- CompendiumService[F].parseProtocol(protocolId, target)
           resp         <- parserResult.fold(pe => InternalServerError(pe.msg), mp => Ok(mp.protocol.raw))
         } yield resp).recoverWith {
-          case idError: ProtocolIdError => BadRequest(idError.message)
+          case e: ProtocolIdError       => BadRequest(ErrorMessage(e.message))
           case _                        => InternalServerError()
         }
     }

--- a/modules/server/src/main/scala/higherkindness/compendium/models/ProtocolMetadata.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/models/ProtocolMetadata.scala
@@ -18,4 +18,4 @@ package higherkindness.compendium.models
 
 import higherkindness.compendium.core.refinements.ProtocolId
 
-case class ProtocolMetadata(idlName: IdlName, protocolId: ProtocolId)
+case class ProtocolMetadata(protocolId: ProtocolId, idlName: IdlName)

--- a/modules/server/src/main/scala/higherkindness/compendium/models/ProtocolMetadata.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/models/ProtocolMetadata.scala
@@ -16,6 +16,6 @@
 
 package higherkindness.compendium.models
 
-import higherkindness.compendium.core.refinements.ProtocolId
+import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 
-case class ProtocolMetadata(protocolId: ProtocolId, idlName: IdlName)
+case class ProtocolMetadata(id: ProtocolId, idlName: IdlName, version: ProtocolVersion)

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
@@ -45,7 +45,7 @@ object FileStorage {
         for {
           filename <- Sync[F].catchNonFatal {
             Option(
-              new File(s"${config.path}${File.separator}${protocolMetadata.protocolId}")
+              new File(s"${config.path}${File.separator}${protocolMetadata.id}")
                 .listFiles())
               .fold(Option.empty[String])(_.headOption.map(_.getAbsolutePath))
           }

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
@@ -70,7 +70,7 @@ object FileStorage {
 
       override def exists(id: ProtocolId): F[Boolean] = {
         val filter = new FilenameFilter {
-          override def accept(dir: File, name: String): Boolean = name.startsWith(id.value)
+          override def accept(dir: File, name: String): Boolean = name.startsWith(s"${id.value}_")
         }
 
         Sync[F].catchNonFatal(new File(s"${config.path}").listFiles(filter)).map(_.nonEmpty)

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
@@ -20,7 +20,7 @@ import java.io.{File, PrintWriter}
 
 import cats.effect.Sync
 import cats.implicits._
-import higherkindness.compendium.core.refinements.ProtocolId
+import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 import higherkindness.compendium.models.{FullProtocol, Protocol, ProtocolMetadata}
 import higherkindness.compendium.models.config.FileStorageConfig
 
@@ -29,7 +29,7 @@ object FileStorage {
   implicit def impl[F[_]: Sync](config: FileStorageConfig): Storage[F] =
     new Storage[F] {
 
-      override def store(id: ProtocolId, protocol: Protocol): F[Unit] =
+      override def store(id: ProtocolId, version: ProtocolVersion, protocol: Protocol): F[Unit] =
         for {
           _ <- Sync[F].catchNonFatal(new File(s"${config.path}${File.separator}$id").mkdirs())
           file <- Sync[F].catchNonFatal(

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
@@ -37,7 +37,7 @@ object FileStorage {
   private[storage] def buildFilename(id: ProtocolId, version: ProtocolVersion): String =
     s"${id.value}_${f"${version.value}%05d"}.protocol"
 
-  implicit def impl[F[_]: Sync](config: FileStorageConfig): Storage[F] =
+  def apply[F[_]: Sync](config: FileStorageConfig): Storage[F] =
     new Storage[F] {
 
       override def store(id: ProtocolId, version: ProtocolVersion, protocol: Protocol): F[Unit] = {

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/FileStorage.scala
@@ -16,7 +16,7 @@
 
 package higherkindness.compendium.storage
 
-import java.io.{File, PrintWriter}
+import java.io.{File, FilenameFilter, PrintWriter}
 
 import cats.effect.Sync
 import cats.implicits._
@@ -26,41 +26,55 @@ import higherkindness.compendium.models.config.FileStorageConfig
 
 object FileStorage {
 
+  /**
+   * File pattern should match `{protocol identifier}_{version}.{extension}` where:
+   *
+   * - protocol identifier should comply with
+   * [[higherkindness.compendium.core.refinements.ProtocolId]] predicates
+   * - version should be a positive zero-leftpadded five digits version number like 00001
+   * - extension is `protocol`
+   */
+  private[storage] def buildFilename(id: ProtocolId, version: ProtocolVersion): String =
+    s"${id.value}_${f"${version.value}%05d"}.protocol"
+
   implicit def impl[F[_]: Sync](config: FileStorageConfig): Storage[F] =
     new Storage[F] {
 
-      override def store(id: ProtocolId, version: ProtocolVersion, protocol: Protocol): F[Unit] =
+      override def store(id: ProtocolId, version: ProtocolVersion, protocol: Protocol): F[Unit] = {
+        val filename = buildFilename(id, version)
+        val path     = s"${config.path}${File.separator}$filename"
+
         for {
-          _ <- Sync[F].catchNonFatal(new File(s"${config.path}${File.separator}$id").mkdirs())
-          file <- Sync[F].catchNonFatal(
-            new File(s"${config.path}${File.separator}$id${File.separator}protocol"))
+          _    <- Sync[F].catchNonFatal(new File(config.path.toUri).mkdirs)
+          file <- Sync[F].catchNonFatal(new File(path))
           _ <- Sync[F].catchNonFatal {
             val printWriter = new PrintWriter(file)
             printWriter.write(protocol.raw)
             printWriter.close()
           }
         } yield ()
+      }
 
-      override def recover(protocolMetadata: ProtocolMetadata): F[Option[FullProtocol]] =
+      override def recover(protocolMetadata: ProtocolMetadata): F[Option[FullProtocol]] = {
+        val filename = buildFilename(protocolMetadata.id, protocolMetadata.version)
+        val file     = new File(s"${config.path}${File.separator}$filename")
+        def checkFile(exists: Boolean): Option[File] =
+          Option(exists).filter(identity).map(_ => file)
+
         for {
-          filename <- Sync[F].catchNonFatal {
-            Option(
-              new File(s"${config.path}${File.separator}${protocolMetadata.id}")
-                .listFiles())
-              .fold(Option.empty[String])(_.headOption.map(_.getAbsolutePath))
-          }
-          source <- Sync[F].catchNonFatal { filename.map(scala.io.Source.fromFile) }
-          protocol <- Sync[F].catchNonFatal {
-            source.flatMap { s =>
-              filename.map { _ =>
-                Protocol(s.mkString)
-              }
-            }
-          }
-        } yield protocol.map(FullProtocol(protocolMetadata, _))
+          maybeFile   <- Sync[F].catchNonFatal(file.exists).map(checkFile)
+          maybeSource <- Sync[F].catchNonFatal(maybeFile.map(scala.io.Source.fromFile))
+          maybeProto  <- Sync[F].catchNonFatal(maybeSource.map(source => Protocol(source.mkString)))
+        } yield maybeProto.map(FullProtocol(protocolMetadata, _))
+      }
 
-      override def exists(id: ProtocolId): F[Boolean] =
-        Sync[F].catchNonFatal(new File(s"${config.path}${File.separator}$id")).map(_.exists)
+      override def exists(id: ProtocolId): F[Boolean] = {
+        val filter = new FilenameFilter {
+          override def accept(dir: File, name: String): Boolean = name.startsWith(id.value)
+        }
+
+        Sync[F].catchNonFatal(new File(s"${config.path}").listFiles(filter)).map(_.nonEmpty)
+      }
     }
 
 }

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/Storage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/Storage.scala
@@ -16,12 +16,12 @@
 
 package higherkindness.compendium.storage
 
-import higherkindness.compendium.core.refinements.ProtocolId
+import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 import higherkindness.compendium.models._
 
 trait Storage[F[_]] {
 
-  def store(id: ProtocolId, protocol: Protocol): F[Unit]
+  def store(id: ProtocolId, version: ProtocolVersion, protocol: Protocol): F[Unit]
   def recover(metadata: ProtocolMetadata): F[Option[FullProtocol]]
   def exists(id: ProtocolId): F[Boolean]
 }

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/pg/PgStorage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/pg/PgStorage.scala
@@ -20,14 +20,14 @@ import cats.effect.Bracket
 import cats.syntax.functor._
 import doobie.implicits._
 import doobie.util.transactor.Transactor
-import higherkindness.compendium.core.refinements.ProtocolId
+import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 import higherkindness.compendium.models.{FullProtocol, Protocol, ProtocolMetadata}
 import higherkindness.compendium.storage.Storage
 
 private class PgStorage[F[_]: Bracket[?[_], Throwable]](xa: Transactor[F]) extends Storage[F] {
 
-  override def store(id: ProtocolId, protocol: Protocol): F[Unit] =
-    Queries.storeProtocol(id, protocol).run.void.transact(xa)
+  override def store(id: ProtocolId, version: ProtocolVersion, protocol: Protocol): F[Unit] =
+    Queries.storeProtocol(id, version, protocol).run.void.transact(xa)
 
   override def recover(metadata: ProtocolMetadata): F[Option[FullProtocol]] =
     Queries

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/pg/PgStorage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/pg/PgStorage.scala
@@ -31,7 +31,7 @@ private class PgStorage[F[_]: Bracket[?[_], Throwable]](xa: Transactor[F]) exten
 
   override def recover(metadata: ProtocolMetadata): F[Option[FullProtocol]] =
     Queries
-      .recoverProtocol(metadata.protocolId)
+      .recoverProtocol(metadata.id)
       .option
       .map(_.map(FullProtocol(metadata, _)))
       .transact(xa)

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/pg/PgStorage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/pg/PgStorage.scala
@@ -31,7 +31,7 @@ private class PgStorage[F[_]: Bracket[?[_], Throwable]](xa: Transactor[F]) exten
 
   override def recover(metadata: ProtocolMetadata): F[Option[FullProtocol]] =
     Queries
-      .recoverProtocol(metadata.id)
+      .recoverProtocol(metadata.id, metadata.version)
       .option
       .map(_.map(FullProtocol(metadata, _)))
       .transact(xa)

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/pg/Queries.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/pg/Queries.scala
@@ -32,13 +32,11 @@ object Queries {
         ON CONFLICT (id, version) DO NOTHING
        """.update
 
-  def recoverProtocol(id: ProtocolId): Query0[Protocol] =
+  def recoverProtocol(id: ProtocolId, version: ProtocolVersion): Query0[Protocol] =
     sql"""
         SELECT protocol
         FROM protocols
-        WHERE id=$id
-        ORDER BY version DESC
-        LIMIT 1
+        WHERE id=$id AND version=$version
       """.query[Protocol]
 
   def protocolExists(id: ProtocolId): Query0[Boolean] =

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/pg/Queries.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/pg/Queries.scala
@@ -18,21 +18,28 @@ package higherkindness.compendium.storage.pg
 
 import doobie.syntax.string._
 import doobie.{Query0, Update0}
-import higherkindness.compendium.core.refinements.ProtocolId
+import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
+import higherkindness.compendium.db.queries.metas._
 import higherkindness.compendium.models.Protocol
 import higherkindness.compendium.storage.pg.implicits._
 
 object Queries {
 
-  def storeProtocol(id: ProtocolId, protocol: Protocol): Update0 =
+  def storeProtocol(id: ProtocolId, version: ProtocolVersion, protocol: Protocol): Update0 =
     sql"""
         INSERT INTO protocols 
-        VALUES ($id, $protocol)
-        ON CONFLICT (id) DO UPDATE SET protocol = EXCLUDED.protocol
+        VALUES ($id, $version, $protocol)
+        ON CONFLICT (id, version) DO NOTHING
        """.update
 
   def recoverProtocol(id: ProtocolId): Query0[Protocol] =
-    sql"""SELECT protocol FROM protocols WHERE id=$id""".query[Protocol]
+    sql"""
+        SELECT protocol
+        FROM protocols
+        WHERE id=$id
+        ORDER BY version DESC
+        LIMIT 1
+      """.query[Protocol]
 
   def protocolExists(id: ProtocolId): Query0[Boolean] =
     sql"""SELECT exists (SELECT true FROM protocols WHERE id=$id)""".query[Boolean]

--- a/modules/server/src/test/scala/higherkindness/compendium/CompendiumArbitrary.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/CompendiumArbitrary.scala
@@ -32,9 +32,9 @@ trait CompendiumArbitrary {
   implicit val protocolIdArbitrary: Arbitrary[ProtocolId] = Arbitrary {
     Gen
       .nonEmptyListOf(
-        Gen.oneOf(Gen.alphaNumChar, Gen.const('-'), Gen.const('.'))
+        Gen.frequency(95 -> Gen.alphaNumChar, 4 -> Gen.const('-'), 1 -> Gen.const('.'))
       )
-      .suchThat(_.length > 10)
+      .suchThat(id => id.length > 10 && id.length < 200)
       .map(id => ProtocolId.unsafeFrom(id.mkString))
   }
 
@@ -46,7 +46,7 @@ trait CompendiumArbitrary {
     (
       protocolIdArbitrary.arbitrary,
       idlNamesArbitrary.arbitrary,
-      Arbitrary.arbitrary[ProtocolVersion])
+      Arbitrary.arbitrary[ProtocolVersion].filter(_.value < 100000))
       .mapN(ProtocolMetadata.apply)
   }
 

--- a/modules/server/src/test/scala/higherkindness/compendium/CompendiumArbitrary.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/CompendiumArbitrary.scala
@@ -42,7 +42,7 @@ trait CompendiumArbitrary {
   }
 
   implicit val metaProtocolArbitrary: Arbitrary[ProtocolMetadata] = Arbitrary {
-    (idlNamesArbitrary.arbitrary, protocolIdArbitrary.arbitrary)
+    (protocolIdArbitrary.arbitrary, idlNamesArbitrary.arbitrary)
       .mapN(ProtocolMetadata.apply)
   }
 

--- a/modules/server/src/test/scala/higherkindness/compendium/CompendiumArbitrary.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/CompendiumArbitrary.scala
@@ -21,7 +21,6 @@ import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 import higherkindness.compendium.models.{IdlName, Protocol, ProtocolMetadata}
 import org.scalacheck._
 import org.scalacheck.cats.implicits._
-import eu.timepit.refined.scalacheck.numeric._
 
 trait CompendiumArbitrary {
 
@@ -34,8 +33,7 @@ trait CompendiumArbitrary {
       .nonEmptyListOf(
         Gen.frequency(95 -> Gen.alphaNumChar, 4 -> Gen.const('-'), 1 -> Gen.const('.'))
       )
-      .suchThat(id => id.length > 10 && id.length < 200)
-      .map(id => ProtocolId.unsafeFrom(id.mkString))
+      .map(id => ProtocolId.unsafeFrom(id.mkString.take(200)))
   }
 
   implicit val idlNamesArbitrary: Arbitrary[IdlName] = Arbitrary {
@@ -46,8 +44,8 @@ trait CompendiumArbitrary {
     (
       protocolIdArbitrary.arbitrary,
       idlNamesArbitrary.arbitrary,
-      Arbitrary.arbitrary[ProtocolVersion].filter(_.value < 100000))
-      .mapN(ProtocolMetadata.apply)
+      Gen.choose(1, 99999).map(ProtocolVersion.unsafeFrom)
+    ).mapN(ProtocolMetadata.apply)
   }
 
   implicit val differentIdentifiersArb: Arbitrary[DifferentIdentifiers] = Arbitrary {

--- a/modules/server/src/test/scala/higherkindness/compendium/CompendiumArbitrary.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/CompendiumArbitrary.scala
@@ -17,10 +17,11 @@
 package higherkindness.compendium
 
 import cats.syntax.apply._
-import higherkindness.compendium.core.refinements.ProtocolId
+import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 import higherkindness.compendium.models.{IdlName, Protocol, ProtocolMetadata}
 import org.scalacheck._
 import org.scalacheck.cats.implicits._
+import eu.timepit.refined.scalacheck.numeric._
 
 trait CompendiumArbitrary {
 
@@ -42,7 +43,10 @@ trait CompendiumArbitrary {
   }
 
   implicit val metaProtocolArbitrary: Arbitrary[ProtocolMetadata] = Arbitrary {
-    (protocolIdArbitrary.arbitrary, idlNamesArbitrary.arbitrary)
+    (
+      protocolIdArbitrary.arbitrary,
+      idlNamesArbitrary.arbitrary,
+      Arbitrary.arbitrary[ProtocolVersion])
       .mapN(ProtocolMetadata.apply)
   }
 

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumRefinementsSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumRefinementsSpec.scala
@@ -18,7 +18,6 @@ package higherkindness.compendium.core
 
 import cats.syntax.either._
 import higherkindness.compendium.core.refinements._
-import higherkindness.compendium.models.ProtocolIdentifierError
 import org.specs2.mutable.Specification
 
 object CompendiumRefinementsSpec extends Specification {
@@ -37,7 +36,7 @@ object CompendiumRefinementsSpec extends Specification {
     "Returns an error if refining was unsuccessful due to invalid chars" >> {
       val rawProtocolId = "invalid_dom@in"
 
-      val err = ProtocolIdentifierError("err")
+      val err = "err"
 
       val refine = ProtocolId.from(rawProtocolId).leftMap(_ => err)
 
@@ -47,7 +46,7 @@ object CompendiumRefinementsSpec extends Specification {
     "Returns an error if refining was unsuccessful due to very long size" >> {
       val rawProtocolId = (1 to 10).flatMap(_ => 'a' to 'z').mkString
 
-      val err = ProtocolIdentifierError("err")
+      val err = "err"
 
       val refine = ProtocolId.from(rawProtocolId).leftMap(_ => err)
 

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceSpec.scala
@@ -63,7 +63,7 @@ object CompendiumServiceSpec extends Specification with ScalaCheck {
 
   "Recover protocol" >> {
     "Given a identifier we recover the protocol" >> prop { id: ProtocolId =>
-      val protocolMetadata            = ProtocolMetadata(IdlName.Avro, id)
+      val protocolMetadata            = ProtocolMetadata(id, IdlName.Avro)
       implicit val dbService          = new DBServiceStub(true, protocolMetadata.some)
       implicit val storage            = new StorageStub(Some(dummyProtocol), id)
       implicit val protocolUtils      = new ProtocolUtilsStub(dummyProtocol, true)

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceSpec.scala
@@ -62,15 +62,17 @@ object CompendiumServiceSpec extends Specification with ScalaCheck {
   }
 
   "Recover protocol" >> {
-    "Given a identifier we recover the protocol" >> prop { id: ProtocolId =>
-      val protocolMetadata            = ProtocolMetadata(id, IdlName.Avro)
-      implicit val dbService          = new DBServiceStub(true, protocolMetadata.some)
-      implicit val storage            = new StorageStub(Some(dummyProtocol), id)
+    "Given a identifier we recover the protocol" >> prop { metadata: ProtocolMetadata =>
+      implicit val dbService          = new DBServiceStub(true, metadata.some)
+      implicit val storage            = new StorageStub(Some(dummyProtocol), metadata.id)
       implicit val protocolUtils      = new ProtocolUtilsStub(dummyProtocol, true)
       implicit val protoParserService = ProtocolParser.impl[IO]
 
-      CompendiumService.impl[IO].recoverProtocol(id).unsafeRunSync().map(_.protocol) === Some(
-        dummyProtocol)
+      CompendiumService
+        .impl[IO]
+        .recoverProtocol(metadata.id)
+        .unsafeRunSync()
+        .map(_.protocol) === Some(dummyProtocol)
     }
   }
 

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceStub.scala
@@ -17,14 +17,17 @@
 package higherkindness.compendium.core
 
 import cats.effect.IO
-import higherkindness.compendium.core.refinements.ProtocolId
+import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 import higherkindness.compendium.models.parserModels.ParserResult
 import higherkindness.compendium.models._
 
 class CompendiumServiceStub(protocolOpt: Option[FullProtocol], exists: Boolean)
     extends CompendiumService[IO] {
-  override def storeProtocol(id: ProtocolId, protocol: Protocol, idlName: IdlName): IO[Unit] =
-    IO.unit
+  override def storeProtocol(
+      id: ProtocolId,
+      protocol: Protocol,
+      idlName: IdlName): IO[ProtocolVersion] =
+    IO.pure(protocolOpt.map(_.metadata.version).getOrElse(ProtocolVersion(1)))
   override def recoverProtocol(id: ProtocolId): IO[Option[FullProtocol]] = IO(protocolOpt)
   override def existsProtocol(protocolId: ProtocolId): IO[Boolean]       = IO(exists)
 

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceStub.scala
@@ -21,7 +21,7 @@ import higherkindness.compendium.core.refinements.ProtocolId
 import higherkindness.compendium.models.parserModels.ParserResult
 import higherkindness.compendium.models._
 
-class CompendiumServiceStub(val protocolOpt: Option[FullProtocol], exists: Boolean)
+class CompendiumServiceStub(protocolOpt: Option[FullProtocol], exists: Boolean)
     extends CompendiumService[IO] {
   override def storeProtocol(id: ProtocolId, protocol: Protocol, idlName: IdlName): IO[Unit] =
     IO.unit
@@ -29,4 +29,9 @@ class CompendiumServiceStub(val protocolOpt: Option[FullProtocol], exists: Boole
   override def existsProtocol(protocolId: ProtocolId): IO[Boolean]       = IO(exists)
 
   override def parseProtocol(protocolId: ProtocolId, target: IdlName): IO[ParserResult] = ???
+}
+
+object CompendiumServiceStub {
+  def apply(protocolOpt: Option[FullProtocol], exists: Boolean): CompendiumServiceStub =
+    new CompendiumServiceStub(protocolOpt, exists)
 }

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceStub.scala
@@ -32,6 +32,15 @@ class CompendiumServiceStub(protocolOpt: Option[FullProtocol], exists: Boolean)
   override def existsProtocol(protocolId: ProtocolId): IO[Boolean]       = IO(exists)
 
   override def parseProtocol(protocolId: ProtocolId, target: IdlName): IO[ParserResult] = ???
+
+  override def recoverProtocolVersion(
+      id: ProtocolId,
+      version: ProtocolVersion): IO[Option[FullProtocol]] = recoverProtocol(id)
+
+  override def parseProtocolVersion(
+      id: ProtocolId,
+      version: ProtocolVersion,
+      target: IdlName): IO[ParserResult] = parseProtocol(id, target)
 }
 
 object CompendiumServiceStub {

--- a/modules/server/src/test/scala/higherkindness/compendium/db/DBServiceStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/db/DBServiceStub.scala
@@ -29,6 +29,6 @@ class DBServiceStub(val exists: Boolean, protocol: Option[ProtocolMetadata] = No
   override def selectProtocolMetadataById(id: ProtocolId): IO[Option[ProtocolMetadata]] =
     protocol.fold[IO[Option[ProtocolMetadata]]](IO.raiseError(new Throwable("Protocol not found")))(
       mp =>
-        if (mp.protocolId == id) IO(protocol)
+        if (mp.id == id) IO(protocol)
         else IO.raiseError(new Throwable("Protocol not found")))
 }

--- a/modules/server/src/test/scala/higherkindness/compendium/db/DBServiceStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/db/DBServiceStub.scala
@@ -18,17 +18,18 @@ package higherkindness.compendium.db
 
 import cats.effect.IO
 import higherkindness.compendium.models.{IdlName, ProtocolMetadata}
-import higherkindness.compendium.core.refinements.ProtocolId
+import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 
-class DBServiceStub(val exists: Boolean, protocol: Option[ProtocolMetadata] = None)
+class DBServiceStub(val exists: Boolean, metadata: Option[ProtocolMetadata] = None)
     extends DBService[IO] {
-  override def upsertProtocol(id: ProtocolId, idlNames: IdlName): IO[Unit] = IO.unit
-  override def existsProtocol(id: ProtocolId): IO[Boolean]                 = IO.pure(exists)
-  override def ping(): IO[Boolean]                                         = IO.pure(exists)
+  override def upsertProtocol(id: ProtocolId, idlNames: IdlName): IO[ProtocolVersion] =
+    IO.pure(metadata.map(_.version).getOrElse(ProtocolVersion(1)))
+  override def existsProtocol(id: ProtocolId): IO[Boolean] = IO.pure(exists)
+  override def ping(): IO[Boolean]                         = IO.pure(exists)
 
   override def selectProtocolMetadataById(id: ProtocolId): IO[Option[ProtocolMetadata]] =
-    protocol.fold[IO[Option[ProtocolMetadata]]](IO.raiseError(new Throwable("Protocol not found")))(
+    metadata.fold[IO[Option[ProtocolMetadata]]](IO.raiseError(new Throwable("Protocol not found")))(
       mp =>
-        if (mp.id == id) IO(protocol)
+        if (mp.id == id) IO(metadata)
         else IO.raiseError(new Throwable("Protocol not found")))
 }

--- a/modules/server/src/test/scala/higherkindness/compendium/db/MetadataQueriesSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/db/MetadataQueriesSpec.scala
@@ -14,28 +14,25 @@
  * limitations under the License.
  */
 
-package higherkindness.compendium.storage.pg
+package higherkindness.compendium.db
 
 import doobie.specs2._
-import higherkindness.compendium.core.refinements.ProtocolId
-import higherkindness.compendium.db.MigrationsMode.Data
-import higherkindness.compendium.db.PGHelper
-import higherkindness.compendium.models.Protocol
+import higherkindness.compendium.db.MigrationsMode.Metadata
+import higherkindness.compendium.db.queries.Queries
 import org.specs2.specification.Scope
 
-class QueriesSpec extends PGHelper(Data) with IOChecker {
+class MetadataQueriesSpec extends PGHelper(Metadata) with IOChecker {
 
-  "Queries" should {
+  "MetadataQueries" should {
     "match db model" in new context {
-      check(Queries.protocolExists(protocolId))
-      check(Queries.storeProtocol(protocolId, protocol))
-      check(Queries.recoverProtocol(protocolId))
+      check(Queries.checkIfExistsQ(protocolId))
+      check(Queries.upsertProtocolIdQ(protocolId, idlName))
     }
   }
 
   trait context extends Scope {
-    val protocolId = ProtocolId("my.test.protocol.id")
-    val protocol   = Protocol("Raw protocol content")
+    val protocolId: String = "my.test.protocol.id"
+    val idlName: String    = "Protobuf"
   }
 
 }

--- a/modules/server/src/test/scala/higherkindness/compendium/http/RootServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/http/RootServiceSpec.scala
@@ -86,8 +86,8 @@ object RootServiceSpec extends Specification with ScalaCheck {
         override def storeProtocol(
             id: ProtocolId,
             protocol: Protocol,
-            idlNames: IdlName): IO[Unit] =
-          IO.raiseError[Unit](new org.apache.avro.SchemaParseException(""))
+            idlNames: IdlName): IO[ProtocolVersion] =
+          IO.raiseError[ProtocolVersion](new org.apache.avro.SchemaParseException(""))
       }
 
       val request: Request[IO] =

--- a/modules/server/src/test/scala/higherkindness/compendium/http/RootServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/http/RootServiceSpec.scala
@@ -17,7 +17,7 @@
 package higherkindness.compendium.http
 
 import cats.effect.IO
-import higherkindness.compendium.core.refinements.ProtocolId
+import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 import higherkindness.compendium.core.CompendiumServiceStub
 import higherkindness.compendium.models._
 import higherkindness.compendium.CompendiumArbitrary.protocolIdArbitrary
@@ -37,12 +37,12 @@ object RootServiceSpec extends Specification with ScalaCheck {
   sequential
 
   private val dummyProtocol: ProtocolId => FullProtocol = (pid: ProtocolId) =>
-    FullProtocol(ProtocolMetadata(pid, IdlName.Avro), Protocol(""))
+    FullProtocol(ProtocolMetadata(pid, IdlName.Avro, ProtocolVersion(1)), Protocol(""))
 
   "GET /protocol/id" >> {
     "If successs returns a valid protocol and status code" >> {
       implicit val compendiumService =
-        new CompendiumServiceStub(Some(dummyProtocol(ProtocolId("id"))), true)
+        CompendiumServiceStub(Some(dummyProtocol(ProtocolId("id"))), true)
 
       val request: Request[IO] =
         Request[IO](method = Method.GET, uri = Uri(path = s"/protocol/my.proto"))
@@ -55,7 +55,7 @@ object RootServiceSpec extends Specification with ScalaCheck {
     }
 
     "If protocol not found returns not found" >> {
-      implicit val compendiumService = new CompendiumServiceStub(None, true)
+      implicit val compendiumService = CompendiumServiceStub(None, true)
 
       val request: Request[IO] =
         Request[IO](method = Method.GET, uri = Uri(path = s"/protocol/my.proto"))
@@ -68,7 +68,7 @@ object RootServiceSpec extends Specification with ScalaCheck {
 
     "If protocol identifier is malformed returns bad request" >> {
       implicit val compendiumService =
-        new CompendiumServiceStub(Some(dummyProtocol(ProtocolId("id"))), true)
+        CompendiumServiceStub(Some(dummyProtocol(ProtocolId("id"))), true)
 
       val request: Request[IO] =
         Request[IO](method = Method.GET, uri = Uri(path = "/protocol/not_valid@"))
@@ -104,7 +104,7 @@ object RootServiceSpec extends Specification with ScalaCheck {
 
     "If protocol is valid returns Created and the location in the headers" >> prop {
       id: ProtocolId =>
-        implicit val compendiumService = new CompendiumServiceStub(None, false)
+        implicit val compendiumService = CompendiumServiceStub(None, false)
 
         val request: Request[IO] =
           Request[IO](
@@ -123,7 +123,7 @@ object RootServiceSpec extends Specification with ScalaCheck {
     }
 
     "If protocol identifier is malformed returns bad request" >> {
-      implicit val compendiumService = new CompendiumServiceStub(None, false)
+      implicit val compendiumService = CompendiumServiceStub(None, false)
 
       val request: Request[IO] =
         Request[IO](
@@ -139,7 +139,7 @@ object RootServiceSpec extends Specification with ScalaCheck {
 
     "If protocol IDL Name is not valid returns not found" >> {
       implicit val compendiumService =
-        new CompendiumServiceStub(Some(dummyProtocol(ProtocolId("id"))), true)
+        CompendiumServiceStub(Some(dummyProtocol(ProtocolId("id"))), true)
 
       val request: Request[IO] =
         Request[IO](
@@ -153,7 +153,7 @@ object RootServiceSpec extends Specification with ScalaCheck {
     }
 
     "If json is invalid returns a 400 Bad Request" >> prop { id: ProtocolId =>
-      implicit val compendiumService = new CompendiumServiceStub(None, false)
+      implicit val compendiumService = CompendiumServiceStub(None, false)
 
       case class Malformed(malformed: String)
 
@@ -173,7 +173,7 @@ object RootServiceSpec extends Specification with ScalaCheck {
 
     "If protocol is valid and it was already in compendium returns Ok and the location in the headers" >> prop {
       id: ProtocolId =>
-        implicit val compendiumService = new CompendiumServiceStub(None, true)
+        implicit val compendiumService = CompendiumServiceStub(None, true)
 
         val request: Request[IO] =
           Request[IO](

--- a/modules/server/src/test/scala/higherkindness/compendium/http/RootServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/http/RootServiceSpec.scala
@@ -37,7 +37,7 @@ object RootServiceSpec extends Specification with ScalaCheck {
   sequential
 
   private val dummyProtocol: ProtocolId => FullProtocol = (pid: ProtocolId) =>
-    FullProtocol(ProtocolMetadata(IdlName.Avro, pid), Protocol(""))
+    FullProtocol(ProtocolMetadata(pid, IdlName.Avro), Protocol(""))
 
   "GET /protocol/id" >> {
     "If successs returns a valid protocol and status code" >> {

--- a/modules/server/src/test/scala/higherkindness/compendium/parser/ProtocolParserSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/parser/ProtocolParserSpec.scala
@@ -17,7 +17,7 @@
 package higherkindness.compendium.parser
 
 import cats.effect.IO
-import higherkindness.compendium.core.refinements.ProtocolId
+import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 import higherkindness.compendium.models._
 import org.specs2.mutable.Specification
 
@@ -28,7 +28,7 @@ class ProtocolParserSpec extends Specification {
   val parser = ProtocolParser.impl[IO]
 
   "ProtocolParser should parse a simple Avro Schema to Mu" >> {
-    val protocolMetadata = ProtocolMetadata(ProtocolId("id"), IdlName.Avro)
+    val protocolMetadata = ProtocolMetadata(ProtocolId("id"), IdlName.Avro, ProtocolVersion(1))
     val fullProtocol     = FullProtocol(protocolMetadata, Protocol(simpleAvroExample))
 
     parser
@@ -38,7 +38,7 @@ class ProtocolParserSpec extends Specification {
   }
 
   "ProtocolParser should parse a simple Protobuf Schema to Mu" >> {
-    val protocolMetadata = ProtocolMetadata(ProtocolId("id"), IdlName.Avro)
+    val protocolMetadata = ProtocolMetadata(ProtocolId("id"), IdlName.Avro, ProtocolVersion(1))
     val fullProtocol     = FullProtocol(protocolMetadata, Protocol(simpleAvroExample))
     parser
       .parse(fullProtocol, IdlName.Mu)

--- a/modules/server/src/test/scala/higherkindness/compendium/parser/ProtocolParserSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/parser/ProtocolParserSpec.scala
@@ -28,7 +28,7 @@ class ProtocolParserSpec extends Specification {
   val parser = ProtocolParser.impl[IO]
 
   "ProtocolParser should parse a simple Avro Schema to Mu" >> {
-    val protocolMetadata = ProtocolMetadata(IdlName.Avro, ProtocolId("id"))
+    val protocolMetadata = ProtocolMetadata(ProtocolId("id"), IdlName.Avro)
     val fullProtocol     = FullProtocol(protocolMetadata, Protocol(simpleAvroExample))
 
     parser
@@ -38,7 +38,7 @@ class ProtocolParserSpec extends Specification {
   }
 
   "ProtocolParser should parse a simple Protobuf Schema to Mu" >> {
-    val protocolMetadata = ProtocolMetadata(IdlName.Avro, ProtocolId("id"))
+    val protocolMetadata = ProtocolMetadata(ProtocolId("id"), IdlName.Avro)
     val fullProtocol     = FullProtocol(protocolMetadata, Protocol(simpleAvroExample))
     parser
       .parse(fullProtocol, IdlName.Mu)

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/FileStorageSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/FileStorageSpec.scala
@@ -59,35 +59,33 @@ object FileStorageSpec extends Specification with ScalaCheck with BeforeAfterAll
   sequential
 
   "Store a file" >> {
-    "Successfully stores a file" >> prop {
-      (protocolMetadata: ProtocolMetadata, protocol: Protocol) =>
-        val storageProtocolFile = storageProtocol(protocolMetadata.id)
+    "Successfully stores a file" >> prop { (metadata: ProtocolMetadata, protocol: Protocol) =>
+      val storageProtocolFile = storageProtocol(metadata.id)
 
-        val io = fileStorage
-          .store(protocolMetadata.id, protocol)
-          .map(_ => storageDirectory.exists && storageProtocolFile.exists)
+      val io = fileStorage
+        .store(metadata.id, metadata.version, protocol)
+        .map(_ => storageDirectory.exists && storageProtocolFile.exists)
 
-        io.unsafeRunSync() should beTrue
+      io.unsafeRunSync() should beTrue
     }
 
     "Successfully stores and recovers a file" >> prop {
-      (protocolMetadata: ProtocolMetadata, protocol: Protocol) =>
+      (metadata: ProtocolMetadata, protocol: Protocol) =>
         val file = for {
-          _ <- fileStorage.store(protocolMetadata.id, protocol)
-          f <- fileStorage.recover(protocolMetadata)
+          _ <- fileStorage.store(metadata.id, metadata.version, protocol)
+          f <- fileStorage.recover(metadata)
         } yield f
 
-        file.unsafeRunSync() should beSome(FullProtocol(protocolMetadata, protocol))
+        file.unsafeRunSync() should beSome(FullProtocol(metadata, protocol))
     }
 
-    "Returns true if there is a file" >> prop {
-      (protocolMetadata: ProtocolMetadata, protocol: Protocol) =>
-        val file = for {
-          _      <- fileStorage.store(protocolMetadata.id, protocol)
-          exists <- fileStorage.exists(protocolMetadata.id)
-        } yield exists
+    "Returns true if there is a file" >> prop { (metadata: ProtocolMetadata, protocol: Protocol) =>
+      val file = for {
+        _      <- fileStorage.store(metadata.id, metadata.version, protocol)
+        exists <- fileStorage.exists(metadata.id)
+      } yield exists
 
-        file.unsafeRunSync() should beTrue
+      file.unsafeRunSync() should beTrue
     }
 
     "Returns false if there is no file" >> prop { protocolId: ProtocolId =>

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/FileStorageSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/FileStorageSpec.scala
@@ -61,10 +61,10 @@ object FileStorageSpec extends Specification with ScalaCheck with BeforeAfterAll
   "Store a file" >> {
     "Successfully stores a file" >> prop {
       (protocolMetadata: ProtocolMetadata, protocol: Protocol) =>
-        val storageProtocolFile = storageProtocol(protocolMetadata.protocolId)
+        val storageProtocolFile = storageProtocol(protocolMetadata.id)
 
         val io = fileStorage
-          .store(protocolMetadata.protocolId, protocol)
+          .store(protocolMetadata.id, protocol)
           .map(_ => storageDirectory.exists && storageProtocolFile.exists)
 
         io.unsafeRunSync() should beTrue
@@ -73,7 +73,7 @@ object FileStorageSpec extends Specification with ScalaCheck with BeforeAfterAll
     "Successfully stores and recovers a file" >> prop {
       (protocolMetadata: ProtocolMetadata, protocol: Protocol) =>
         val file = for {
-          _ <- fileStorage.store(protocolMetadata.protocolId, protocol)
+          _ <- fileStorage.store(protocolMetadata.id, protocol)
           f <- fileStorage.recover(protocolMetadata)
         } yield f
 
@@ -83,8 +83,8 @@ object FileStorageSpec extends Specification with ScalaCheck with BeforeAfterAll
     "Returns true if there is a file" >> prop {
       (protocolMetadata: ProtocolMetadata, protocol: Protocol) =>
         val file = for {
-          _      <- fileStorage.store(protocolMetadata.protocolId, protocol)
-          exists <- fileStorage.exists(protocolMetadata.protocolId)
+          _      <- fileStorage.store(protocolMetadata.id, protocol)
+          exists <- fileStorage.exists(protocolMetadata.id)
         } yield exists
 
         file.unsafeRunSync() should beTrue

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/FileStorageSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/FileStorageSpec.scala
@@ -40,7 +40,7 @@ object FileStorageSpec extends Specification with ScalaCheck with BeforeAfterAll
   private[this] def storageProtocol(id: ProtocolId, version: ProtocolVersion) =
     new Directory(new File(s"$basePath${File.separator}${FileStorage.buildFilename(id, version)}"))
 
-  private[this] lazy val fileStorage: Storage[IO] = FileStorage.impl[IO](storageConfig)
+  private[this] lazy val fileStorage: Storage[IO] = FileStorage[IO](storageConfig)
 
   override def beforeAll(): Unit = {
     val _ = baseDirectory.createDirectory()

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/FileStorageSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/FileStorageSpec.scala
@@ -21,7 +21,7 @@ import java.nio.file.Paths
 
 import cats.effect.IO
 import higherkindness.compendium.CompendiumArbitrary._
-import higherkindness.compendium.core.refinements.ProtocolId
+import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 import higherkindness.compendium.models._
 import higherkindness.compendium.models.config.FileStorageConfig
 import org.specs2.ScalaCheck
@@ -34,11 +34,11 @@ object FileStorageSpec extends Specification with ScalaCheck with BeforeAfterAll
 
   private[this] lazy val basePath: String = "/tmp/filespec"
   private[this] lazy val storageConfig: FileStorageConfig = FileStorageConfig(
-    Paths.get(s"$basePath/files"))
+    Paths.get(s"$basePath"))
   private[this] lazy val baseDirectory    = new Directory(new File(basePath))
   private[this] lazy val storageDirectory = new Directory(new File(storageConfig.path.toUri))
-  private[this] def storageProtocol(id: ProtocolId) =
-    new Directory(new File(s"${storageConfig.path}/$id/protocol"))
+  private[this] def storageProtocol(id: ProtocolId, version: ProtocolVersion) =
+    new Directory(new File(s"$basePath${File.separator}${FileStorage.buildFilename(id, version)}"))
 
   private[this] lazy val fileStorage: Storage[IO] = FileStorage.impl[IO](storageConfig)
 
@@ -60,7 +60,7 @@ object FileStorageSpec extends Specification with ScalaCheck with BeforeAfterAll
 
   "Store a file" >> {
     "Successfully stores a file" >> prop { (metadata: ProtocolMetadata, protocol: Protocol) =>
-      val storageProtocolFile = storageProtocol(metadata.id)
+      val storageProtocolFile = storageProtocol(metadata.id, metadata.version)
 
       val io = fileStorage
         .store(metadata.id, metadata.version, protocol)

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/StorageStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/StorageStub.scala
@@ -32,7 +32,7 @@ class StorageStub(val proto: Option[Protocol], val identifier: ProtocolId)
     } *> IO.unit
 
   override def recover(metadata: ProtocolMetadata): IO[Option[FullProtocol]] =
-    if (metadata.protocolId == identifier) IO(proto.map(FullProtocol(metadata, _)))
+    if (metadata.id == identifier) IO(proto.map(FullProtocol(metadata, _)))
     else IO(None)
 
   override def exists(id: ProtocolId): IO[Boolean] =

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/StorageStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/StorageStub.scala
@@ -18,21 +18,26 @@ package higherkindness.compendium.storage
 
 import cats.effect.IO
 import cats.syntax.apply._
-import higherkindness.compendium.core.refinements.ProtocolId
+import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 import higherkindness.compendium.models._
 import org.specs2.matcher.Matchers
 
-class StorageStub(val proto: Option[Protocol], val identifier: ProtocolId)
+class StorageStub(
+    val proto: Option[Protocol],
+    val identifier: ProtocolId,
+    val protoVersion: ProtocolVersion)
     extends Storage[IO]
     with Matchers {
-  override def store(id: ProtocolId, protocol: Protocol): IO[Unit] =
+  override def store(id: ProtocolId, version: ProtocolVersion, protocol: Protocol): IO[Unit] =
     IO {
       proto === Some(protocol)
+      version === protoVersion
       id === identifier
     } *> IO.unit
 
   override def recover(metadata: ProtocolMetadata): IO[Option[FullProtocol]] =
-    if (metadata.id == identifier) IO(proto.map(FullProtocol(metadata, _)))
+    if (metadata.id == identifier && metadata.version == protoVersion)
+      IO(proto.map(FullProtocol(metadata, _)))
     else IO(None)
 
   override def exists(id: ProtocolId): IO[Boolean] =

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/pg/PgStorageSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/pg/PgStorageSpec.scala
@@ -18,7 +18,7 @@ package higherkindness.compendium.storage.pg
 
 import cats.effect.IO
 import cats.implicits._
-import higherkindness.compendium.core.refinements.ProtocolId
+import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 import higherkindness.compendium.db.MigrationsMode.Data
 import higherkindness.compendium.db.PGHelper
 import higherkindness.compendium.models.{FullProtocol, IdlName, Protocol, ProtocolMetadata}
@@ -31,7 +31,7 @@ class PgStorageSpec extends PGHelper(Data) {
 
     "insert protocol correctly" in {
       val id        = ProtocolId("p1")
-      val metadata  = ProtocolMetadata(id, IdlName.Avro)
+      val metadata  = ProtocolMetadata(id, IdlName.Avro, ProtocolVersion(1))
       val proto     = Protocol("the new protocol content")
       val fullProto = FullProtocol(metadata, proto)
 
@@ -44,7 +44,7 @@ class PgStorageSpec extends PGHelper(Data) {
 
     "update protocol correctly" in {
       val id        = ProtocolId("proto1")
-      val metadata  = ProtocolMetadata(id, IdlName.Mu)
+      val metadata  = ProtocolMetadata(id, IdlName.Mu, ProtocolVersion(1))
       val proto1    = Protocol("The protocol one content")
       val proto2    = Protocol("The protocol two content")
       val fullProto = FullProtocol(metadata, proto2)

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/pg/PgStorageSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/pg/PgStorageSpec.scala
@@ -31,12 +31,13 @@ class PgStorageSpec extends PGHelper(Data) {
 
     "insert protocol correctly" in {
       val id        = ProtocolId("p1")
-      val metadata  = ProtocolMetadata(id, IdlName.Avro, ProtocolVersion(1))
+      val version   = ProtocolVersion(1)
+      val metadata  = ProtocolMetadata(id, IdlName.Avro, version)
       val proto     = Protocol("the new protocol content")
       val fullProto = FullProtocol(metadata, proto)
 
-      val result: IO[Option[FullProtocol]] = pgStorage.store(id, proto) >> pgStorage.recover(
-        metadata)
+      val result: IO[Option[FullProtocol]] = pgStorage.store(id, version, proto) >> pgStorage
+        .recover(metadata)
 
       result.unsafeRunSync must ===(fullProto.some)
 
@@ -44,14 +45,15 @@ class PgStorageSpec extends PGHelper(Data) {
 
     "update protocol correctly" in {
       val id        = ProtocolId("proto1")
-      val metadata  = ProtocolMetadata(id, IdlName.Mu, ProtocolVersion(1))
+      val version1  = ProtocolVersion(1)
+      val version2  = ProtocolVersion(2)
       val proto1    = Protocol("The protocol one content")
       val proto2    = Protocol("The protocol two content")
+      val metadata  = ProtocolMetadata(id, IdlName.Mu, version2)
       val fullProto = FullProtocol(metadata, proto2)
 
-      val result: IO[Option[FullProtocol]] = pgStorage.store(id, proto1) >> pgStorage.store(
-        id,
-        proto2) >> pgStorage
+      val result: IO[Option[FullProtocol]] = pgStorage.store(id, version1, proto1) >> pgStorage
+        .store(id, version2, proto2) >> pgStorage
         .recover(metadata)
 
       result.unsafeRunSync must ===(fullProto.some)
@@ -64,10 +66,11 @@ class PgStorageSpec extends PGHelper(Data) {
     }
 
     "return true when the protocol exists" in {
-      val id    = ProtocolId("pId3")
-      val proto = Protocol("Another protocol")
+      val id      = ProtocolId("pId3")
+      val version = ProtocolVersion(1)
+      val proto   = Protocol("Another protocol")
 
-      val result: IO[Boolean] = pgStorage.store(id, proto) >> pgStorage.exists(id)
+      val result: IO[Boolean] = pgStorage.store(id, version, proto) >> pgStorage.exists(id)
 
       result.unsafeRunSync must ===(true)
     }

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/pg/PgStorageSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/pg/PgStorageSpec.scala
@@ -31,7 +31,7 @@ class PgStorageSpec extends PGHelper(Data) {
 
     "insert protocol correctly" in {
       val id        = ProtocolId("p1")
-      val metadata  = ProtocolMetadata(IdlName.Avro, id)
+      val metadata  = ProtocolMetadata(id, IdlName.Avro)
       val proto     = Protocol("the new protocol content")
       val fullProto = FullProtocol(metadata, proto)
 
@@ -44,7 +44,7 @@ class PgStorageSpec extends PGHelper(Data) {
 
     "update protocol correctly" in {
       val id        = ProtocolId("proto1")
-      val metadata  = ProtocolMetadata(IdlName.Mu, id)
+      val metadata  = ProtocolMetadata(id, IdlName.Mu)
       val proto1    = Protocol("The protocol one content")
       val proto2    = Protocol("The protocol two content")
       val fullProto = FullProtocol(metadata, proto2)

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/pg/StorageQueriesSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/pg/StorageQueriesSpec.scala
@@ -14,25 +14,29 @@
  * limitations under the License.
  */
 
-package higherkindness.compendium.db
+package higherkindness.compendium.storage.pg
 
 import doobie.specs2._
-import higherkindness.compendium.db.MigrationsMode.Metadata
-import higherkindness.compendium.db.queries.Queries
+import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
+import higherkindness.compendium.db.MigrationsMode.Data
+import higherkindness.compendium.db.PGHelper
+import higherkindness.compendium.models.Protocol
 import org.specs2.specification.Scope
 
-class QueriesSpec extends PGHelper(Metadata) with IOChecker {
+class StorageQueriesSpec extends PGHelper(Data) with IOChecker {
 
-  "Queries" should {
+  "StorageQueries" should {
     "match db model" in new context {
-      check(Queries.checkIfExistsQ(protocolId))
-      check(Queries.upsertProtocolIdQ(protocolId, idlName))
+      check(Queries.protocolExists(protocolId))
+      check(Queries.storeProtocol(protocolId, version, protocol))
+      check(Queries.recoverProtocol(protocolId))
     }
   }
 
   trait context extends Scope {
-    val protocolId: String = "my.test.protocol.id"
-    val idlName: String    = "Protobuf"
+    val protocolId = ProtocolId("my.test.protocol.id")
+    val version    = ProtocolVersion(1)
+    val protocol   = Protocol("Raw protocol content")
   }
 
 }

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/pg/StorageQueriesSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/pg/StorageQueriesSpec.scala
@@ -29,7 +29,7 @@ class StorageQueriesSpec extends PGHelper(Data) with IOChecker {
     "match db model" in new context {
       check(Queries.protocolExists(protocolId))
       check(Queries.storeProtocol(protocolId, version, protocol))
-      check(Queries.recoverProtocol(protocolId))
+      check(Queries.recoverProtocol(protocolId, version))
     }
   }
 


### PR DESCRIPTION
Closes #92 

Sorry for this huge PR. Anyway, is a simple one despite the number of file changes. What does this PR include?

- A new refined type `ProtocolVersion` which is a positive integer
- Adds the protocol version to `ProtocolMetadata` to keep track of latest version for each `ProtocolId`
- Storing a new protocol version works as follows:
    1. Attempts to store metadata, that returns a `ProtocolVersion` (starting from `1`)
    2. Attempts to store protocol using the version from the previous step
- Cosmetic changes here and there, adapt tests
- Adds an optional query param `version` to GET protocol endpoint
- Updates compendium client to reflect that `version` change

Storing first metadata, then use that protocol version could be reversed: storing protocol first, returning the auto incremental version, then store metadata. I just made the choice on the fly, but it should not be difficult to fix that if we feel it suits better our purpose when compendium evolves.