### PR TITLE
Fix/Update CI Images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jobs:
       sudo: false
       language: scala
       jdk:
-        - oraclejdk8
+        - openjdk8
       scala:
         - 2.12.8
       before_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN sbt update
 COPY . .
 RUN sbt $PROJECT/universal:packageBin
 
-FROM openjdk:8u181-jre-slim
+FROM openjdk:8u212-jre-slim
 ARG VERSION
 ARG PROJECT
 ENV version=$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt as builder
+FROM hseeberger/scala-sbt:8u212_1.2.8_2.12.8 as builder
 ARG PROJECT
 WORKDIR /build
 COPY project project

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY project project
 COPY build.sbt .
 RUN sbt update
 COPY . .
-RUN sbt $PROJECT/universal:packageBin
+RUN sbt $PROJECT/universal:packageZipTarball
 
 FROM openjdk:8u212-jre-slim
 ARG VERSION
@@ -13,6 +13,6 @@ ARG PROJECT
 ENV version=$VERSION
 ENV name=compendium-$PROJECT
 COPY --from=builder /build/modules/$PROJECT/target/universal/. .
-RUN unzip -o ./${name}-$VERSION.zip
+RUN tar -zxvf ./${name}-$VERSION.tgz
 RUN chmod +x ${name}-$VERSION/bin/$name
 ENTRYPOINT ${name}-$version/bin/$name


### PR DESCRIPTION
- Fix failing CI because scala-sbt:latest does not exist anymore.
- Update scala-sbt to 8u212 - 1.2.8 - 2.12.8
- Update openjdk to 8u212
- Migrate from oraclejdk to openjdk