### PR TITLE
Use resource to handle Protobuf temp file creation

### DIFF
--- a/modules/server/src/main/scala/higherkindness/compendium/Main.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/Main.scala
@@ -51,7 +51,7 @@ object CompendiumStreamApp {
       _                              <- Stream.eval(Migrations.makeMigrations(conf.metadata.storage, List(migrations)))
       implicit0(storage: Storage[F]) <- Stream.resource(initStorage[F](conf.protocols.storage))
       metadataTransactor             <- Stream.resource(createTransactor(conf.metadata.storage))
-      implicit0(dbService: MetadataStorage[F])       = PgMetadataStorage[F](metadataTransactor)
+      implicit0(metadataStore: MetadataStorage[F])   = PgMetadataStorage[F](metadataTransactor)
       implicit0(utils: ProtocolUtils[F])             = ProtocolUtils.impl[F]
       implicit0(transformer: ProtocolTransformer[F]) = SkeuomorphProtocolTransformer[F]
       implicit0(compendium: CompendiumService[F])    = CompendiumService.impl[F]

--- a/modules/server/src/main/scala/higherkindness/compendium/transformer/protobuf/parsing.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/transformer/protobuf/parsing.scala
@@ -33,14 +33,14 @@ object parsing {
     def printWriterCreation(tmpFile: Path): F[PrintWriter] =
       Sync[F].delay(new PrintWriter(tmpFile.toFile))
 
-    val result = for {
+    val protoSource = for {
       tmpFile   <- Resource.liftF(tmpFileCreation)
       tmpWriter <- Resource.fromAutoCloseable(printWriterCreation(tmpFile))
       _         <- Resource.liftF(Sync[F].delay(tmpWriter.write(raw)))
       _         <- Resource.liftF(Sync[F].delay(tmpWriter.close()))
     } yield ProtoSource(tmpFile.getFileName.toString, tmpFile.getParent.toString)
 
-    result.use(transformToTarget)
+    protoSource.use(transformToTarget)
   }
 
 }

--- a/modules/server/src/test/scala/higherkindness/compendium/transformer/SkeuomorphProtocolTransformerSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/transformer/SkeuomorphProtocolTransformerSpec.scala
@@ -40,8 +40,9 @@ class SkeuomorphProtocolTransformerSpec extends Specification {
     }
 
     "Transform a simple Protobuf Schema to Mu" >> {
-      val protocolMetadata = ProtocolMetadata(ProtocolId("id"), IdlName.Avro, ProtocolVersion(1))
-      val fullProtocol     = FullProtocol(protocolMetadata, Protocol(simpleAvroExample))
+      val protocolMetadata =
+        ProtocolMetadata(ProtocolId("id"), IdlName.Protobuf, ProtocolVersion(1))
+      val fullProtocol = FullProtocol(protocolMetadata, Protocol(simpleProtobufExample))
       transformer
         .transform(fullProtocol, IdlName.Mu)
         .map(_.isRight)

--- a/modules/server/src/test/scala/higherkindness/compendium/transformer/SkeuomorphProtocolTransformerSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/transformer/SkeuomorphProtocolTransformerSpec.scala
@@ -33,20 +33,19 @@ class SkeuomorphProtocolTransformerSpec extends Specification {
       val protocolMetadata = ProtocolMetadata(ProtocolId("id"), IdlName.Avro, ProtocolVersion(1))
       val fullProtocol     = FullProtocol(protocolMetadata, Protocol(simpleAvroExample))
 
-      transformer
-        .transform(fullProtocol, IdlName.Mu)
-        .map(_.isRight)
-        .unsafeRunSync()
+      val transformResult = transformer.transform(fullProtocol, IdlName.Mu)
+
+      transformResult.unsafeRunSync() should beRight
     }
 
     "Transform a simple Protobuf Schema to Mu" >> {
       val protocolMetadata =
         ProtocolMetadata(ProtocolId("id"), IdlName.Protobuf, ProtocolVersion(1))
       val fullProtocol = FullProtocol(protocolMetadata, Protocol(simpleProtobufExample))
-      transformer
-        .transform(fullProtocol, IdlName.Mu)
-        .map(_.isRight)
-        .unsafeRunSync()
+
+      val transformResult = transformer.transform(fullProtocol, IdlName.Mu)
+
+      transformResult.unsafeRunSync() should beRight
     }
   }
 


### PR DESCRIPTION
Closes #101 

A quick solution with `Resource` to handle temp file creation used into protobuf parsing.

I also cleaned up a bit the skeuo protocol transformer.