### PR TITLE
Add optional version param and not found error to transformation endpoint

### DIFF
--- a/modules/common/src/main/scala/higherkindness/compendium/models/errors.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models/errors.scala
@@ -18,6 +18,7 @@ package higherkindness.compendium.models
 
 final case class ProtocolIdError(msg: String)      extends Exception(msg)
 final case class ProtocolVersionError(msg: String) extends Exception(msg)
-final case class UnknownTargetError(msg: String)   extends Exception(msg)
+final case class ProtocolNotFound(msg: String)     extends Exception(msg)
+final case class UnknownIdlName(msg: String)       extends Exception(msg)
 final case class SchemaError(msg: String)          extends Exception(msg)
 final case class UnknownError(msg: String)         extends Exception(msg)

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceStub.scala
@@ -36,10 +36,7 @@ class CompendiumServiceStub(protocolOpt: Option[FullProtocol], exists: Boolean)
 
   override def existsProtocol(protocolId: ProtocolId): IO[Boolean] = IO.pure(exists)
 
-  override def transformProtocol(
-      id: ProtocolId,
-      target: IdlName,
-      version: Option[ProtocolVersion]): IO[TransformResult] =
+  override def transformProtocol(fullProtocol: FullProtocol, target: IdlName): IO[TransformResult] =
     IO.pure(protocolOpt.toRight(TransformError("err")))
 }
 


### PR DESCRIPTION
This PR changes a bit how transformation method in compendium service works. Now it accepts a full protocol that is previously retrieved at the endpoint.

Transformation endpoint now accepts an optional version parameter like protocol retrieval endpoint. Compendium client params need to be changed accordingly (I'm doing it in this PR).

I also added a new error to handle protocol non-existence in retrieval and transformation endpoints.