### PR TITLE
Implemented a new way to handle errors.

### DIFF
--- a/modules/client/src/main/scala/higherkindness/compendium/CompendiumClient.scala
+++ b/modules/client/src/main/scala/higherkindness/compendium/CompendiumClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/client/src/main/scala/higherkindness/compendium/models/config/CompendiumClientConfig.scala
+++ b/modules/client/src/main/scala/higherkindness/compendium/models/config/CompendiumClientConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/client/src/test/scala/higherkindness/compendium/CompendiumClientSpec.scala
+++ b/modules/client/src/test/scala/higherkindness/compendium/CompendiumClientSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/client/src/test/scala/higherkindness/compendium/ConfigSpec.scala
+++ b/modules/client/src/test/scala/higherkindness/compendium/ConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/common/src/main/scala/higherkindness/compendium/models/ErrorResponse.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models/ErrorResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/common/src/main/scala/higherkindness/compendium/models/IdlName.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models/IdlName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/common/src/main/scala/higherkindness/compendium/models/Protocol.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models/Protocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/common/src/main/scala/higherkindness/compendium/models/config/HttpConfig.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models/config/HttpConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/common/src/main/scala/higherkindness/compendium/models/errors.scala
+++ b/modules/common/src/main/scala/higherkindness/compendium/models/errors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,13 @@
 
 package higherkindness.compendium.models
 
-final case class ProtocolIdError(msg: String)      extends Exception(msg)
-final case class ProtocolVersionError(msg: String) extends Exception(msg)
-final case class ProtocolNotFound(msg: String)     extends Exception(msg)
-final case class UnknownIdlName(msg: String)       extends Exception(msg)
-final case class SchemaError(msg: String)          extends Exception(msg)
-final case class UnknownError(msg: String)         extends Exception(msg)
+abstract class CompendiumError(error: String) extends Exception(error)
+
+final case class FileNotFound(fileName: String)
+    extends CompendiumError(s"File with name $fileName not found")
+final case class ProtocolIdError(msg: String)      extends CompendiumError(msg)
+final case class ProtocolVersionError(msg: String) extends CompendiumError(msg)
+final case class ProtocolNotFound(msg: String)     extends CompendiumError(msg)
+final case class UnknownIdlName(msg: String)       extends CompendiumError(msg)
+final case class SchemaError(msg: String)          extends CompendiumError(msg)
+final case class UnknownError(msg: String)         extends CompendiumError(msg)

--- a/modules/server/src/main/scala/higherkindness/compendium/CompendiumServerStream.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/CompendiumServerStream.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/main/scala/higherkindness/compendium/Main.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/Main.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/main/scala/higherkindness/compendium/core/doobie/implicits.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/core/doobie/implicits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/main/scala/higherkindness/compendium/core/refinements.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/core/refinements.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/main/scala/higherkindness/compendium/http/HealthService.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/HealthService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/main/scala/higherkindness/compendium/http/QueryParams.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/QueryParams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/main/scala/higherkindness/compendium/http/RoutesMiddleware.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/RoutesMiddleware.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.compendium.http
+
+import cats.MonadError
+import cats.data.{Kleisli, OptionT}
+import cats.syntax.option._
+import cats.syntax.applicativeError._
+import higherkindness.compendium.models._
+import higherkindness.compendium.models.transformer.types.SchemaParseException
+import org.http4s.{HttpRoutes, Response, Status}
+
+object RoutesMiddleware {
+
+  def middleware[F[_]: MonadError[*[_], Throwable]](httpRoutes: HttpRoutes[F]): HttpRoutes[F] = {
+
+    def genResponse(s: Status, msg: String): Option[Response[F]] =
+      Response[F](s).withEntity(msg).some
+
+    def badRequest(msg: String) = genResponse(Status.BadRequest, msg)
+    def notFound(msg: String)   = genResponse(Status.NotFound, msg)
+
+    Kleisli { req =>
+      OptionT {
+        httpRoutes.run(req).value.handleError {
+          case e: SchemaParseException                 => badRequest(e.getMessage)
+          case e: org.http4s.InvalidMessageBodyFailure => badRequest(e.getMessage)
+          case e: ProtocolIdError                      => badRequest(e.getMessage)
+          case e: ProtocolNotFound                     => notFound(e.getMessage)
+          case e: UnknownIdlName                       => badRequest(e.getMessage)
+          case e: ProtocolVersionError                 => badRequest(e.getMessage)
+          case e                                       => genResponse(Status.InternalServerError, e.getMessage)
+        }
+      }
+    }
+
+  }
+
+}

--- a/modules/server/src/main/scala/higherkindness/compendium/http/RoutesMiddleware.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/http/RoutesMiddleware.scala
@@ -22,7 +22,7 @@ import cats.syntax.option._
 import cats.syntax.applicativeError._
 import higherkindness.compendium.models._
 import higherkindness.compendium.models.transformer.types.SchemaParseException
-import org.http4s.{HttpRoutes, Response, Status}
+import org.http4s._
 
 object RoutesMiddleware {
 
@@ -37,13 +37,13 @@ object RoutesMiddleware {
     Kleisli { req =>
       OptionT {
         httpRoutes.run(req).value.handleError {
-          case e: SchemaParseException                 => badRequest(e.getMessage)
-          case e: org.http4s.InvalidMessageBodyFailure => badRequest(e.getMessage)
-          case e: ProtocolIdError                      => badRequest(e.getMessage)
-          case e: ProtocolNotFound                     => notFound(e.getMessage)
-          case e: UnknownIdlName                       => badRequest(e.getMessage)
-          case e: ProtocolVersionError                 => badRequest(e.getMessage)
-          case e                                       => genResponse(Status.InternalServerError, e.getMessage)
+          case e: SchemaParseException      => badRequest(e.getMessage)
+          case e: InvalidMessageBodyFailure => badRequest(e.getMessage)
+          case e: ProtocolIdError           => badRequest(e.getMessage)
+          case e: ProtocolNotFound          => notFound(e.getMessage)
+          case e: UnknownIdlName            => badRequest(e.getMessage)
+          case e: ProtocolVersionError      => badRequest(e.getMessage)
+          case e                            => genResponse(Status.InternalServerError, e.getMessage)
         }
       }
     }

--- a/modules/server/src/main/scala/higherkindness/compendium/metadata/MetadataStorage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/metadata/MetadataStorage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 
 trait MetadataStorage[F[_]] {
   def store(id: ProtocolId, idlName: IdlName): F[ProtocolVersion]
-  def retrieve(id: ProtocolId): F[Option[ProtocolMetadata]]
+  def retrieve(id: ProtocolId): F[ProtocolMetadata]
   def exists(id: ProtocolId): F[Boolean]
   def ping: F[Boolean]
 }

--- a/modules/server/src/main/scala/higherkindness/compendium/metadata/pg/Queries.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/metadata/pg/Queries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/main/scala/higherkindness/compendium/migrations/Migrations.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/migrations/Migrations.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/main/scala/higherkindness/compendium/models/FullProtocol.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/models/FullProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/main/scala/higherkindness/compendium/models/HealthResponse.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/models/HealthResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/main/scala/higherkindness/compendium/models/ProtocolMetadata.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/models/ProtocolMetadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/main/scala/higherkindness/compendium/models/config/CompendiumServerConfig.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/models/config/CompendiumServerConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/main/scala/higherkindness/compendium/models/config/StorageConfig.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/models/config/StorageConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/main/scala/higherkindness/compendium/models/transformer/types.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/models/transformer/types.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,11 @@
 
 package higherkindness.compendium.models.transformer
 
-import higherkindness.compendium.models.FullProtocol
+import higherkindness.compendium.models.CompendiumError
 
 object types {
 
-  final case class TransformError(msg: String) extends Exception(msg)
-
-  type TransformResult = Either[TransformError, FullProtocol]
+  final case class TransformError(msg: String)       extends CompendiumError(msg)
+  final case class SchemaParseException(msg: String) extends CompendiumError(msg)
 
 }

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/Storage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/Storage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import higherkindness.compendium.models._
 trait Storage[F[_]] {
 
   def store(id: ProtocolId, version: ProtocolVersion, protocol: Protocol): F[Unit]
-  def retrieve(metadata: ProtocolMetadata): F[Option[FullProtocol]]
+  def retrieve(metadata: ProtocolMetadata): F[FullProtocol]
   def exists(id: ProtocolId): F[Boolean]
 }
 

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/files/FileStorage.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/files/FileStorage.scala
@@ -62,7 +62,7 @@ object FileStorage {
         def checkFile: F[File] =
           Sync[F]
             .delay(file.exists)
-            .ifM(Sync[F].delay(file), Sync[F].raiseError(FileNotFound(filename)))
+            .ifM(Sync[F].pure(file), Sync[F].raiseError(FileNotFound(filename)))
 
         for {
           file   <- checkFile

--- a/modules/server/src/main/scala/higherkindness/compendium/storage/pg/Queries.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/storage/pg/Queries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/main/scala/higherkindness/compendium/transformer/ProtocolTransformer.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/transformer/ProtocolTransformer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,10 @@ package higherkindness.compendium.transformer
 
 import cats.effect.Sync
 import higherkindness.compendium.models.{FullProtocol, IdlName}
-import higherkindness.compendium.models.transformer.types.TransformResult
 
 trait ProtocolTransformer[F[_]] {
 
-  def transform(protocol: FullProtocol, target: IdlName): F[TransformResult]
+  def transform(protocol: FullProtocol, target: IdlName): F[FullProtocol]
 }
 
 object ProtocolTransformer {

--- a/modules/server/src/main/scala/higherkindness/compendium/transformer/protobuf/parsing.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/transformer/protobuf/parsing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import higherkindness.skeuomorph.protobuf.ParseProto.ProtoSource
 
 object parsing {
 
-  def transformProtobuf[F[_]: Sync: Bracket[?[_], Throwable]](raw: String)(
+  def transformProtobuf[F[_]: Sync: Bracket[*[_], Throwable]](raw: String)(
       transformToTarget: ProtoSource => F[FullProtocol]): F[FullProtocol] = {
 
     val tmpFileCreation =

--- a/modules/server/src/main/scala/higherkindness/compendium/transformer/skeuomorph/SkeuomorphProtocolTransformer.scala
+++ b/modules/server/src/main/scala/higherkindness/compendium/transformer/skeuomorph/SkeuomorphProtocolTransformer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package higherkindness.compendium.transformer.skeuomorph
 
 import cats.effect.Sync
 import cats.implicits._
-import higherkindness.compendium.models.transformer.types.{TransformError, TransformResult}
 import higherkindness.compendium.models.{FullProtocol, IdlName, Protocol, ProtocolMetadata}
 import higherkindness.compendium.transformer.ProtocolTransformer
 import higherkindness.skeuomorph.protobuf.ParseProto.ProtoSource
@@ -63,8 +62,8 @@ object SkeuomorphProtocolTransformer {
           transformProtobuf(fp.protocol.raw)(protobufToMu(_, fp.metadata))
       }
 
-    override def transform(protocol: FullProtocol, target: IdlName): F[TransformResult] =
-      skeuomorphTransformation(protocol, target).map(_.asRight[TransformError])
+    override def transform(protocol: FullProtocol, target: IdlName): F[FullProtocol] =
+      skeuomorphTransformation(protocol, target)
   }
 
 }

--- a/modules/server/src/test/scala/higherkindness/compendium/CompendiumArbitrary.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/CompendiumArbitrary.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/test/scala/higherkindness/compendium/ConfigSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/ConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/test/scala/higherkindness/compendium/DifferentIdentifiers.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/DifferentIdentifiers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumRefinementsSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumRefinementsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,8 +70,8 @@ object CompendiumServiceSpec extends Specification with ScalaCheck {
       CompendiumService
         .impl[IO]
         .retrieveProtocol(metadata.id, metadata.version.some)
-        .unsafeRunSync()
-        .map(_.protocol) === dummyProtocol.some
+        .map(_.protocol)
+        .unsafeRunSync() === dummyProtocol
     }
   }
 

--- a/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/CompendiumServiceStub.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package higherkindness.compendium.core
 
 import cats.effect.IO
 import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
-import higherkindness.compendium.models.transformer.types.{TransformError, TransformResult}
 import higherkindness.compendium.models._
 
 class CompendiumServiceStub(protocolOpt: Option[FullProtocol], exists: Boolean)
@@ -27,17 +26,20 @@ class CompendiumServiceStub(protocolOpt: Option[FullProtocol], exists: Boolean)
   override def storeProtocol(
       id: ProtocolId,
       protocol: Protocol,
-      idlName: IdlName): IO[ProtocolVersion] =
+      idlName: IdlName
+  ): IO[ProtocolVersion] =
     IO.pure(protocolOpt.map(_.metadata.version).getOrElse(ProtocolVersion(1)))
 
   override def retrieveProtocol(
       id: ProtocolId,
-      version: Option[ProtocolVersion]): IO[Option[FullProtocol]] = IO.pure(protocolOpt)
+      version: Option[ProtocolVersion]
+  ): IO[FullProtocol] =
+    protocolOpt.fold(IO.raiseError[FullProtocol](ProtocolNotFound("Not found")))(fp => IO.pure(fp))
 
   override def existsProtocol(protocolId: ProtocolId): IO[Boolean] = IO.pure(exists)
 
-  override def transformProtocol(fullProtocol: FullProtocol, target: IdlName): IO[TransformResult] =
-    IO.pure(protocolOpt.toRight(TransformError("err")))
+  override def transformProtocol(fullProtocol: FullProtocol, target: IdlName): IO[FullProtocol] =
+    protocolOpt.fold(IO.raiseError[FullProtocol](ProtocolNotFound("Not Found")))(fp => IO.pure(fp))
 }
 
 object CompendiumServiceStub {

--- a/modules/server/src/test/scala/higherkindness/compendium/core/ProtocolUtilsSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/ProtocolUtilsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import cats.effect.IO
 import cats.syntax.apply._
 import higherkindness.compendium.CompendiumArbitrary._
 import higherkindness.compendium.models.Protocol
+import higherkindness.compendium.models.transformer.types.SchemaParseException
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 
@@ -44,7 +45,7 @@ object ProtocolUtilsSpec extends Specification with ScalaCheck {
       protocol: Protocol =>
         validator
           .validateProtocol(protocol)
-          .unsafeRunSync must throwA[org.apache.avro.SchemaParseException]
+          .unsafeRunSync must throwA[SchemaParseException]
     }
 
     "Given multiple protocols validates them sequentially" >> {
@@ -54,7 +55,7 @@ object ProtocolUtilsSpec extends Specification with ScalaCheck {
 
       val validation = validator.validateProtocol(protocol) *> validator.validateProtocol(protocol)
 
-      validation.unsafeRunSync should not(throwA[org.apache.avro.SchemaParseException])
+      validation.unsafeRunSync should not(throwA[SchemaParseException])
     }
   }
 

--- a/modules/server/src/test/scala/higherkindness/compendium/core/ProtocolUtilsStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/core/ProtocolUtilsStub.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/test/scala/higherkindness/compendium/http/HealthServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/http/HealthServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/test/scala/higherkindness/compendium/http/RootServiceSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/http/RootServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import higherkindness.compendium.CompendiumArbitrary._
 import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 import higherkindness.compendium.core.CompendiumServiceStub
 import higherkindness.compendium.models._
+import higherkindness.compendium.models.transformer.types.SchemaParseException
 import io.circe.Encoder
 import io.circe.generic.semiauto.deriveEncoder
 import org.http4s.circe.CirceEntityCodec._
@@ -133,7 +134,7 @@ object RootServiceSpec extends Specification with ScalaCheck {
             id: ProtocolId,
             protocol: Protocol,
             idlNames: IdlName): IO[ProtocolVersion] =
-          IO.raiseError[ProtocolVersion](new org.apache.avro.SchemaParseException(""))
+          IO.raiseError[ProtocolVersion](SchemaParseException(""))
       }
 
       val request: Request[IO] =

--- a/modules/server/src/test/scala/higherkindness/compendium/http/TestEncoders.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/http/TestEncoders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/test/scala/higherkindness/compendium/metadata/MetadataStorageStub.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/metadata/MetadataStorageStub.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package higherkindness.compendium.metadata
 
 import cats.effect.IO
-import higherkindness.compendium.models.{IdlName, ProtocolMetadata}
+import higherkindness.compendium.models.{IdlName, ProtocolMetadata, ProtocolNotFound}
 import higherkindness.compendium.core.refinements.{ProtocolId, ProtocolVersion}
 
 class MetadataStorageStub(val exists: Boolean, metadata: Option[ProtocolMetadata] = None)
@@ -27,9 +27,9 @@ class MetadataStorageStub(val exists: Boolean, metadata: Option[ProtocolMetadata
   override def exists(id: ProtocolId): IO[Boolean] = IO.pure(exists)
   override def ping: IO[Boolean]                   = IO.pure(exists)
 
-  override def retrieve(id: ProtocolId): IO[Option[ProtocolMetadata]] =
-    metadata.fold[IO[Option[ProtocolMetadata]]](IO.raiseError(new Throwable("Protocol not found")))(
+  override def retrieve(id: ProtocolId): IO[ProtocolMetadata] =
+    metadata.fold(IO.raiseError[ProtocolMetadata](ProtocolNotFound("Protocol not found")))(
       mp =>
-        if (mp.id == id) IO(metadata)
-        else IO.raiseError(new Throwable("Protocol not found")))
+        if (mp.id == id) IO(mp)
+        else IO.raiseError[ProtocolMetadata](ProtocolNotFound("Protocol not found")))
 }

--- a/modules/server/src/test/scala/higherkindness/compendium/metadata/PGHelper.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/metadata/PGHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/test/scala/higherkindness/compendium/metadata/pg/MetadataQueriesSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/metadata/pg/MetadataQueriesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/test/scala/higherkindness/compendium/metadata/pg/PgMetadataStorageSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/metadata/pg/PgMetadataStorageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,12 +32,12 @@ class PgMetadataStorageSpec extends PGHelper(Metadata) {
       val id: ProtocolId   = ProtocolId("pId")
       val idlName: IdlName = IdlName.Avro
 
-      val result: IO[Option[ProtocolMetadata]] =
+      val result: IO[ProtocolMetadata] =
         pg.store(id, idlName) >> pg.retrieve(id)
 
       val expected = ProtocolMetadata(id, idlName, ProtocolVersion(1))
 
-      result.unsafeRunSync must ===(Some(expected))
+      result.unsafeRunSync must_=== expected
 
     }
 
@@ -45,13 +45,13 @@ class PgMetadataStorageSpec extends PGHelper(Metadata) {
       val id: ProtocolId   = ProtocolId("pId2")
       val idlName: IdlName = IdlName.Avro
 
-      val result: IO[Option[ProtocolMetadata]] =
+      val result: IO[ProtocolMetadata] =
         pg.store(id, idlName) >> pg.store(id, idlName) >> pg
           .retrieve(id)
 
       val expected = ProtocolMetadata(id, idlName, ProtocolVersion(2))
 
-      result.unsafeRunSync must ===(Some(expected))
+      result.unsafeRunSync must_=== expected
     }
 
     "return false when the protocol does not exist" in {
@@ -67,7 +67,7 @@ class PgMetadataStorageSpec extends PGHelper(Metadata) {
       val result: IO[Boolean] =
         pg.store(id, idlName) >> pg.exists(id)
 
-      result.unsafeRunSync must ===(true)
+      result.unsafeRunSync must_=== true
     }
 
   }

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/files/FileStorageSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/files/FileStorageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ object FileStorageSpec extends Specification with ScalaCheck with BeforeAfterAll
           f <- fileStorage.retrieve(metadata)
         } yield f
 
-        file.unsafeRunSync() should beSome(FullProtocol(metadata, protocol))
+        file.unsafeRunSync() must_=== FullProtocol(metadata, protocol)
     }
 
     "Returns true if there is a file" >> prop { (metadata: ProtocolMetadata, protocol: Protocol) =>

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/pg/PgStorageSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/pg/PgStorageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,10 +36,10 @@ class PgStorageSpec extends PGHelper(Data) {
       val proto     = Protocol("the new protocol content")
       val fullProto = FullProtocol(metadata, proto)
 
-      val result: IO[Option[FullProtocol]] = pgStorage.store(id, version, proto) >> pgStorage
+      val result: IO[FullProtocol] = pgStorage.store(id, version, proto) >> pgStorage
         .retrieve(metadata)
 
-      result.unsafeRunSync must ===(fullProto.some)
+      result.unsafeRunSync must_=== fullProto
     }
 
     "update protocol correctly" in {
@@ -51,11 +51,11 @@ class PgStorageSpec extends PGHelper(Data) {
       val metadata  = ProtocolMetadata(id, IdlName.Mu, version2)
       val fullProto = FullProtocol(metadata, proto2)
 
-      val result: IO[Option[FullProtocol]] = pgStorage.store(id, version1, proto1) >> pgStorage
+      val result: IO[FullProtocol] = pgStorage.store(id, version1, proto1) >> pgStorage
         .store(id, version2, proto2) >> pgStorage
         .retrieve(metadata)
 
-      result.unsafeRunSync must ===(fullProto.some)
+      result.unsafeRunSync must_=== fullProto
     }
 
     "return false when the protocol does not exist" in {
@@ -71,7 +71,7 @@ class PgStorageSpec extends PGHelper(Data) {
 
       val result: IO[Boolean] = pgStorage.store(id, version, proto) >> pgStorage.exists(id)
 
-      result.unsafeRunSync must ===(true)
+      result.unsafeRunSync must_=== true
     }
 
   }

--- a/modules/server/src/test/scala/higherkindness/compendium/storage/pg/StorageQueriesSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/storage/pg/StorageQueriesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/server/src/test/scala/higherkindness/compendium/transformer/SkeuomorphProtocolTransformerSpec.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/transformer/SkeuomorphProtocolTransformerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ class SkeuomorphProtocolTransformerSpec extends Specification {
 
       val transformResult = transformer.transform(fullProtocol, IdlName.Mu)
 
-      transformResult.unsafeRunSync() should beRight
+      transformResult.attempt.unsafeRunSync() should beRight
     }
 
     "Transform a simple Protobuf Schema to Mu" >> {
@@ -45,7 +45,7 @@ class SkeuomorphProtocolTransformerSpec extends Specification {
 
       val transformResult = transformer.transform(fullProtocol, IdlName.Mu)
 
-      transformResult.unsafeRunSync() should beRight
+      transformResult.attempt.unsafeRunSync() should beRight
     }
   }
 

--- a/modules/server/src/test/scala/higherkindness/compendium/transformer/protocols.scala
+++ b/modules/server/src/test/scala/higherkindness/compendium/transformer/protocols.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Errors are not longer as Either; also, nonexisting resources are not Optional anymore. Everything will be used as a MonadError. In this way a unexisting Protocol will raise an error `Sync[F].raiseError` and the computation will finish with that error. For handling errors, I have implemented a middleware at route level so what it does is to capture the computation error result and convert it into the adequate http response.

This is a simple and friendly version of exposed here:
https://typelevel.org/blog/2018/11/28/http4s-error-handling-mtl-2.html