### PR TITLE
Ignore CI workflow on master branch for now

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,10 @@
 ---
 name: CI
 
-on: push
+on:
+  push:
+    branches-ignore:
+      - 'master'
 
 env:
   JAVA_VERSION: adopt@v8


### PR DESCRIPTION
**Release** workflow already builds the docs, executing CI workflow right now just do unnecessary work.