### PR TITLE
Delete sbt plugin section in compendium microsite

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -3,5 +3,4 @@ layout: homeFeatures
 features:
  - first:   ["Schema management", "Store and retrieve your schemas in different formats, schema versioning included."]
  - second:  ["Conversion", "Format-agnostic ensures the ability to handle the most popular schema formats and perform conversions between them."]
- - third:   ["sbt plugin", "Connect to your compendium server easily with its sbt plugin."]
 ---

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -16,6 +16,3 @@ options:
     nested_options:
       - title: Docker
         url: /docs/deployment/docker
-
-  - title: Sbt plugin
-    url: /docs/sbt


### PR DESCRIPTION
### Description
I found that in the compendium microsite, left bar includes a section (pointing to [nowhere](https://higherkindness.io/compendium/docs/sbt)) about the sbt plugin, which has been replaced with the work made in #294 

I don't know how microsites are built, but I think these changes make the section disappear.




