### PR TITLE
Allows executing the migration in a transactional way

### DIFF
--- a/src/main/resources/db/migration/metadata/V2__update_idl_types.sql
+++ b/src/main/resources/db/migration/metadata/V2__update_idl_types.sql
@@ -1,10 +1,6 @@
-ALTER TYPE idl ADD VALUE 'openapiyaml';
-
-UPDATE metaprotocols SET idl_name = 'openapiyaml' WHERE idl_name = 'openapi';
-
 ALTER TYPE idl RENAME TO idl_old;
 
-CREATE TYPE idl as ENUM('avro', 'protobuf', 'mu', 'openapiyaml', 'openapijson', 'scala');
+CREATE TYPE idl as ENUM('avro', 'protobuf', 'mu', 'openapi', 'openapijson', 'scala');
 
 ALTER TABLE metaprotocols ALTER COLUMN idl_name TYPE idl USING idl_name::text::idl;
 

--- a/src/main/scala/higherkindness/compendium/core/ProtocolUtils.scala
+++ b/src/main/scala/higherkindness/compendium/core/ProtocolUtils.scala
@@ -102,7 +102,7 @@ object ProtocolUtils {
                     SchemaParseException("Protobuf schema provided not valid. " + e.getMessage)
                   )
                 )
-            case IdlName.OpenAPIYaml =>
+            case IdlName.OpenAPI =>
               parserOpenAPIYaml(protocol.raw)
                 .map(_ => protocol)
                 .handleErrorWith(e =>

--- a/src/main/scala/higherkindness/compendium/migrations/Migrations.scala
+++ b/src/main/scala/higherkindness/compendium/migrations/Migrations.scala
@@ -34,7 +34,6 @@ object Migrations {
     F.delay {
       Flyway
         .configure()
-        .mixed(true)
         .dataSource(conf.jdbcUrl, conf.username, conf.password)
         .locations(migrations: _*)
         .load()

--- a/src/main/scala/higherkindness/compendium/models/IdlName.scala
+++ b/src/main/scala/higherkindness/compendium/models/IdlName.scala
@@ -27,7 +27,7 @@ object IdlName extends Enum[IdlName] with CirceEnum[IdlName] {
   case object Avro        extends IdlName with Lowercase
   case object Protobuf    extends IdlName with Lowercase
   case object Mu          extends IdlName with Lowercase
-  case object OpenAPIYaml extends IdlName with Lowercase
+  case object OpenAPI     extends IdlName with Lowercase
   case object OpenAPIJson extends IdlName with Lowercase
   case object Scala       extends IdlName with Lowercase
 }

--- a/src/test/scala/higherkindness/compendium/core/ProtocolUtilsSpec.scala
+++ b/src/test/scala/higherkindness/compendium/core/ProtocolUtilsSpec.scala
@@ -97,7 +97,7 @@ object ProtocolUtilsSpec extends Specification with ScalaCheck {
       stream.close()
 
       validator
-        .validateProtocol(protocol, IdlName.OpenAPIYaml)
+        .validateProtocol(protocol, IdlName.OpenAPI)
         .unsafeRunSync === protocol
     }
 
@@ -108,7 +108,7 @@ object ProtocolUtilsSpec extends Specification with ScalaCheck {
       stream.close()
 
       validator
-        .validateProtocol(protocol, IdlName.OpenAPIYaml)
+        .validateProtocol(protocol, IdlName.OpenAPI)
         .unsafeRunSync must throwA[SchemaParseException]
     }
 


### PR DESCRIPTION
It seems Flyway doesn't like the `ALTER TYPE( .*)? ADD VALUE`

https://github.com/flyway/flyway/blob/823abf4fb5e40fab3d6cc794634f7b5aca99ccd7/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLParser.java#L35

We could take the openapi yaml as the default for open api.